### PR TITLE
Add 15x15 omok15 training package and config presets

### DIFF
--- a/configs/omok15_full_cuda.yaml
+++ b/configs/omok15_full_cuda.yaml
@@ -1,0 +1,74 @@
+# Full-sized 15x15 Omok profile for CUDA GPUs.
+experiment_name: omok15_full_cuda
+seed: 31
+max_hours: null
+device: CUDA
+use_amp: true
+
+rules:
+  board_size: 15
+  exactly_five: true
+
+network:
+  channels: 96
+  blocks: 8
+  value_hidden: 256
+  se_reduction: 8
+
+selfplay:
+  mcts_backend: python
+  evaluator_backend: torch
+  games_per_iteration: 32
+  batch_size: 32
+  num_workers: 0
+  search_threads: auto
+  inference_batch_size: 512
+  inference_wait_ms: 2.0
+  temperature_moves: 18
+  temperature_end: 0.15
+  dirichlet_alpha: 0.12
+  dirichlet_epsilon: 0.25
+  c_puct: 1.8
+  virtual_loss: 1.0
+  leaves_per_batch: 8
+  simulation_ramp_iterations: 128
+  candidate_mix_fraction: 0.5
+  mixed_iterations_after_promotion: 8
+  simulation_schedule:
+    - fraction: 0.0
+      simulations: 64
+    - fraction: 0.5
+      simulations: 96
+    - fraction: 0.8
+      simulations: 128
+
+optimization:
+  batch_size: 256
+  updates_per_iteration: 96
+  learning_rate: 0.0004
+  min_learning_rate: 0.0002
+  weight_decay: 0.0001
+  grad_clip: 1.0
+  replay_capacity: 120000
+  warmup_games: 128
+  policy_loss_weight: 1.0
+  value_loss_weight: 1.8
+  value_discount: 0.99
+  recency_temperature: 2.0e-5
+
+arena:
+  games: 32
+  simulations: 128
+  accept_win_rate: 0.55
+  min_white_win_rate: 0.1667
+  bootstrap_games: 16
+  bootstrap_simulations: 64
+  bootstrap_accept_win_rate: 0.5
+  bootstrap_min_white_win_rate: 0.1667
+
+checkpoint:
+  directory: checkpoints/omok15_full_cuda
+  save_every_iteration: true
+  save_iteration_interval: 1
+  progress_interval_batches: 2
+  progress_interval_seconds: 20.0

--- a/configs/omok15_quick.yaml
+++ b/configs/omok15_quick.yaml
@@ -1,0 +1,52 @@
+experiment_name: omok15_quick
+seed: 11
+max_iterations: 20
+device: auto
+
+rules:
+  board_size: 15
+  exactly_five: false
+
+network:
+  channels: 64
+  blocks: 4
+  value_hidden: 128
+  se_reduction: 8
+
+selfplay:
+  mcts_backend: python
+  evaluator_backend: torch
+  games_per_iteration: 6
+  batch_size: 6
+  num_workers: auto
+  temperature_moves: 12
+  dirichlet_alpha: 0.12
+  dirichlet_epsilon: 0.20
+  c_puct: 1.8
+  leaves_per_batch: 4
+  simulation_schedule:
+    - fraction: 0.0
+      simulations: 16
+    - fraction: 0.5
+      simulations: 32
+
+optimization:
+  batch_size: 96
+  updates_per_iteration: 20
+  learning_rate: 0.0007
+  weight_decay: 0.0001
+  replay_capacity: 20000
+  warmup_games: 6
+
+arena:
+  games: 2
+  simulations: 24
+  accept_win_rate: 0.55
+  bootstrap_games: 2
+  bootstrap_simulations: 16
+  bootstrap_accept_win_rate: 0.0
+
+checkpoint:
+  directory: checkpoints/omok15_quick
+  save_every_iteration: true
+  save_iteration_interval: 1

--- a/configs/omok15_smoke.yaml
+++ b/configs/omok15_smoke.yaml
@@ -1,0 +1,48 @@
+experiment_name: omok15_smoke
+seed: 5
+max_iterations: 1
+device: auto
+
+rules:
+  board_size: 15
+  exactly_five: false
+
+network:
+  channels: 24
+  blocks: 1
+  value_hidden: 64
+  se_reduction: 8
+
+selfplay:
+  mcts_backend: python
+  evaluator_backend: torch
+  games_per_iteration: 1
+  batch_size: 1
+  num_workers: auto
+  temperature_moves: 6
+  dirichlet_alpha: 0.12
+  dirichlet_epsilon: 0.15
+  c_puct: 1.7
+  leaves_per_batch: 1
+  simulation_schedule:
+    - fraction: 0.0
+      simulations: 4
+
+optimization:
+  batch_size: 8
+  updates_per_iteration: 1
+  learning_rate: 0.001
+  weight_decay: 0.0001
+  replay_capacity: 512
+  warmup_games: 1
+
+arena:
+  games: 0
+  simulations: 0
+  bootstrap_games: 0
+  bootstrap_simulations: 0
+  bootstrap_accept_win_rate: 0.0
+
+checkpoint:
+  directory: checkpoints/omok15_smoke
+  save_every_iteration: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ all = [
 [project.scripts]
 omok-train = "coolrl.omok.train:main"
 omok-plot = "coolrl.omok.plot_metrics:main"
+omok15-train = "coolrl.omok15.train:main"
+omok15-plot = "coolrl.omok15.plot_metrics:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/coolrl/omok15/__init__.py
+++ b/src/coolrl/omok15/__init__.py
@@ -1,0 +1,2 @@
+"""15x15 Omok self-play reinforcement learning package."""
+

--- a/src/coolrl/omok15/arena.py
+++ b/src/coolrl/omok15/arena.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+from loguru import logger
+
+from coolrl.progress import make_progress
+
+from .board import GameState
+from .evaluator import Evaluator
+from .torch_evaluator import build_evaluator
+from .metrics import IterationMetrics
+from .mcts_backend import resolve_mcts_backend
+from .mcts_types import MCTSBackend
+from .openings import build_opening_sequences
+
+
+@dataclass(slots=True)
+class ArenaResult:
+    games: int
+    candidate_wins: int
+    best_wins: int
+    draws: int
+    candidate_black_wins: int
+    candidate_white_wins: int
+    moves: int = 0
+
+    @property
+    def candidate_win_rate(self) -> float:
+        return 0.0 if self.games == 0 else self.candidate_wins / self.games
+
+
+@dataclass(slots=True)
+class ArenaGame:
+    state: GameState
+    candidate_color: int
+    candidate_root: object | None = None
+    best_root: object | None = None
+
+
+class Arena:
+    def __init__(
+        self,
+        candidate_model: object,
+        best_model: object,
+        device: str | None,
+        board_size: int,
+        exactly_five: bool,
+        simulations: int,
+        c_puct: float,
+        leaves_per_batch: int = 1,
+        search_threads: int = 1,
+        virtual_loss: float = 1.0,
+        mcts_backend: str = "python",
+        candidate_evaluator: Evaluator | None = None,
+        best_evaluator: Evaluator | None = None,
+        metrics: IterationMetrics | None = None,
+    ) -> None:
+        self.board_size = board_size
+        self.exactly_five = exactly_five
+        self.simulations = simulations
+        self.c_puct = c_puct
+        self.leaves_per_batch = leaves_per_batch
+        self.search_threads = max(1, int(search_threads))
+        self.virtual_loss = float(virtual_loss)
+        self.mcts_module = resolve_mcts_backend(mcts_backend)
+        self.candidate_evaluator = candidate_evaluator or build_evaluator(candidate_model, backend="torch", device=device)
+        self.best_evaluator = best_evaluator or build_evaluator(best_model, backend="torch", device=device)
+        self.metrics = metrics
+
+    def evaluate(self, games: int) -> ArenaResult:
+        target_games = max(2, games)
+        pair_count = max(1, target_games // 2)
+        openings = build_opening_sequences(self.board_size, pair_count)
+        active_games = self._build_games(openings)
+        result = ArenaResult(
+            games=pair_count * 2,
+            candidate_wins=0,
+            best_wins=0,
+            draws=0,
+            candidate_black_wins=0,
+            candidate_white_wins=0,
+            moves=0,
+        )
+
+        candidate_search = self.mcts_module.MCTS(
+            c_puct=self.c_puct,
+            dirichlet_alpha=0.0,
+            dirichlet_epsilon=0.0,
+            evaluator=self.candidate_evaluator,
+            search_threads=self.search_threads,
+            virtual_loss=self.virtual_loss,
+        )
+        best_search = self.mcts_module.MCTS(
+            c_puct=self.c_puct,
+            dirichlet_alpha=0.0,
+            dirichlet_epsilon=0.0,
+            evaluator=self.best_evaluator,
+            search_threads=self.search_threads,
+            virtual_loss=self.virtual_loss,
+        )
+
+        with make_progress() as progress:
+            task = progress.add_task("Arena", total=len(active_games), status="games")
+            while active_games:
+                candidate_turns = [
+                    game
+                    for game in active_games
+                    if not game.state.terminal and game.state.to_play == game.candidate_color
+                ]
+                best_turns = [
+                    game
+                    for game in active_games
+                    if not game.state.terminal and game.state.to_play != game.candidate_color
+                ]
+                if candidate_turns:
+                    self._advance_games(candidate_turns, candidate_search, candidate=True)
+                if best_turns:
+                    self._advance_games(best_turns, best_search, candidate=False)
+
+                still_active: list[ArenaGame] = []
+                for game in active_games:
+                    if game.state.terminal:
+                        self._record_result(result, game)
+                        progress.update(task, advance=1, status="games")
+                    else:
+                        still_active.append(game)
+                active_games = still_active
+
+        logger.info(
+            "Arena finished: games={} candidate_wins={} best_wins={} draws={} win_rate={:.3f}",
+            result.games,
+            result.candidate_wins,
+            result.best_wins,
+            result.draws,
+            result.candidate_win_rate,
+        )
+        return result
+
+    def _build_games(self, openings: Sequence[Sequence[int]]) -> list[ArenaGame]:
+        games: list[ArenaGame] = []
+        for opening in openings:
+            for candidate_color in (1, -1):
+                state = GameState(board_size=self.board_size, exactly_five=self.exactly_five)
+                for action in opening:
+                    state.apply_action(action)
+                games.append(ArenaGame(state=state, candidate_color=candidate_color))
+        return games
+
+    def _advance_games(self, games: list[ArenaGame], search: MCTSBackend, candidate: bool) -> None:
+        states = [game.state for game in games]
+        roots = [game.candidate_root if candidate else game.best_root for game in games]
+        phase = "arena_candidate" if candidate else "arena_best"
+
+        def run_search() -> list[Any]:
+            return search.search_batch(
+                states,
+                self.simulations,
+                [0.0] * len(states),
+                add_noise=False,
+                roots=roots,
+                leaves_per_batch=self.leaves_per_batch,
+            )
+
+        if self.metrics is None:
+            results = run_search()
+        else:
+            results = self.metrics.time_search(
+                phase,
+                len(states),
+                self.simulations,
+                self.leaves_per_batch,
+                run_search,
+            )
+        for game, result in zip(games, results, strict=True):
+            if candidate:
+                game.candidate_root = result.next_root
+                if game.best_root is not None:
+                    game.best_root = game.best_root.children.get(result.action)
+            else:
+                game.best_root = result.next_root
+                if game.candidate_root is not None:
+                    game.candidate_root = game.candidate_root.children.get(result.action)
+            game.state.apply_action(result.action)
+
+    def _record_result(self, result: ArenaResult, game: ArenaGame) -> None:
+        winner = game.state.winner
+        if winner == 0:
+            result.draws += 1
+        elif winner == game.candidate_color:
+            result.candidate_wins += 1
+            if game.candidate_color == 1:
+                result.candidate_black_wins += 1
+            else:
+                result.candidate_white_wins += 1
+        else:
+            result.best_wins += 1
+        result.moves += game.state.move_count

--- a/src/coolrl/omok15/board.py
+++ b/src/coolrl/omok15/board.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+Action = int
+
+
+@dataclass(slots=True)
+class GameState:
+    board_size: int = 15
+    exactly_five: bool = False
+    board: np.ndarray | None = None
+    to_play: int = 1
+    move_count: int = 0
+    last_action: Action | None = None
+    winner: int = 0
+    terminal: bool = False
+
+    def __post_init__(self) -> None:
+        if self.board_size != 15:
+            raise ValueError("coolrl.omok15 is intentionally fixed to 15x15")
+        if self.board is None:
+            self.board = np.zeros((self.board_size, self.board_size), dtype=np.int8)
+        else:
+            self.board = np.asarray(self.board, dtype=np.int8)
+
+    @property
+    def action_size(self) -> int:
+        return self.board_size * self.board_size
+
+    def clone(self) -> "GameState":
+        return GameState(
+            board_size=self.board_size,
+            exactly_five=self.exactly_five,
+            board=self.board.copy(),
+            to_play=self.to_play,
+            move_count=self.move_count,
+            last_action=self.last_action,
+            winner=self.winner,
+            terminal=self.terminal,
+        )
+
+    def legal_moves(self) -> np.ndarray:
+        if self.terminal:
+            return np.zeros(self.action_size, dtype=bool)
+        return self.board.reshape(-1) == 0
+
+    def apply_action(self, action: Action) -> None:
+        if self.terminal:
+            raise ValueError("cannot play on a terminal position")
+        if not 0 <= action < self.action_size:
+            raise ValueError(f"action out of range: {action}")
+        row, col = divmod(action, self.board_size)
+        if self.board[row, col] != 0:
+            raise ValueError(f"illegal move at {(row, col)}")
+
+        player = self.to_play
+        self.board[row, col] = player
+        self.last_action = action
+        self.move_count += 1
+        self.to_play = -player
+        if self._is_winning_move(row, col, player):
+            self.winner = player
+            self.terminal = True
+        elif self.move_count == self.action_size:
+            self.winner = 0
+            self.terminal = True
+
+    def outcome_for_player(self, player: int) -> float:
+        if not self.terminal:
+            raise ValueError("game is not terminal")
+        if self.winner == 0:
+            return 0.0
+        return 1.0 if self.winner == player else -1.0
+
+    def feature_planes(self) -> np.ndarray:
+        own = (self.board == self.to_play).astype(np.float32)
+        opp = (self.board == -self.to_play).astype(np.float32)
+        last = np.zeros_like(own, dtype=np.float32)
+        if self.last_action is not None:
+            row, col = divmod(self.last_action, self.board_size)
+            last[row, col] = 1.0
+        color = np.full_like(own, 1.0 if self.to_play == 1 else 0.0, dtype=np.float32)
+        return np.stack([own, opp, last, color], axis=0)
+
+    def _is_winning_move(self, row: int, col: int, player: int) -> bool:
+        for dr, dc in ((1, 0), (0, 1), (1, 1), (1, -1)):
+            count = (
+                1
+                + self._count_dir(row, col, dr, dc, player)
+                + self._count_dir(row, col, -dr, -dc, player)
+            )
+            if self.exactly_five:
+                if count == 5:
+                    return True
+            elif count >= 5:
+                return True
+        return False
+
+    def _count_dir(self, row: int, col: int, dr: int, dc: int, player: int) -> int:
+        total = 0
+        r = row + dr
+        c = col + dc
+        while (
+            0 <= r < self.board_size
+            and 0 <= c < self.board_size
+            and self.board[r, c] == player
+        ):
+            total += 1
+            r += dr
+            c += dc
+        return total
+

--- a/src/coolrl/omok15/checkpoint.py
+++ b/src/coolrl/omok15/checkpoint.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import json
+import pickle
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from .config import RunConfig, config_from_dict
+from .torch_network import PolicyValueNet, load_legacy_state_dict
+
+
+def _coerce_cpu(state: Any) -> Any:
+    if isinstance(state, dict):
+        return {key: _coerce_cpu(value) for key, value in state.items()}
+    if torch.is_tensor(state):
+        return state.detach().cpu()
+    if isinstance(state, (list, tuple)):
+        return type(state)(_coerce_cpu(item) for item in state)
+    return state
+
+
+def checkpoint_path(path: str | Path) -> Path:
+    target = Path(path)
+    if target.suffix:
+        return target
+    pt = target.with_suffix(".pt")
+    if pt.exists():
+        return pt
+    legacy = target.with_suffix(".safetensors")
+    if legacy.exists():
+        return legacy
+    return pt
+
+
+def checkpoint_metadata_path(path: str | Path) -> Path:
+    return checkpoint_path(path).with_suffix(".json")
+
+
+def save_checkpoint(
+    path: str | Path,
+    model: PolicyValueNet,
+    config: RunConfig,
+    metadata: dict[str, Any] | None = None,
+    optimizer: torch.optim.Optimizer | None = None,
+    scheduler: torch.optim.lr_scheduler._LRScheduler | None = None,
+) -> Path:
+    target = checkpoint_path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    payload = {
+        "checkpoint_format": "coolrl.omok.torch.v1",
+        "model": _coerce_cpu(model.state_dict()),
+        "optimizer": _coerce_cpu(optimizer.state_dict()) if optimizer is not None else None,
+        "scheduler": _coerce_cpu(scheduler.state_dict()) if scheduler is not None else None,
+        "metadata": {
+            "torch_version": torch.__version__,
+            "config": config.to_dict(),
+            "iteration": 0,
+            **(metadata or {}),
+        },
+    }
+    torch.save(payload, target)
+
+    checkpoint_metadata_path(target).write_text(
+        json.dumps(payload["metadata"], ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return target
+
+
+def _load_legacy_model(path: Path) -> tuple[PolicyValueNet, RunConfig]:
+    from safetensors.numpy import load_file
+
+    raw_metadata_path = checkpoint_metadata_path(path)
+    payload = json.loads(raw_metadata_path.read_text(encoding="utf-8"))
+    config_payload = payload.get("config", payload.get("metadata", {}).get("config"))
+    if config_payload is None:
+        raise ValueError(f"legacy checkpoint metadata does not include config: {raw_metadata_path}")
+    config = config_from_dict(config_payload)
+    model = PolicyValueNet(config.rules.board_size, config.network)
+    load_legacy_state_dict(model, load_file(path))
+    return model, config
+
+
+def load_checkpoint(
+    path: str | Path,
+) -> tuple[PolicyValueNet, RunConfig, dict[str, Any], dict[str, Any] | None, dict[str, Any] | None]:
+    target = checkpoint_path(path)
+    if target.suffix == ".pt":
+        payload = torch.load(target, map_location="cpu", weights_only=False)
+        metadata = payload.get("metadata", {})
+        config = config_from_dict(metadata["config"])
+        model = PolicyValueNet(config.rules.board_size, config.network)
+        model.load_state_dict(payload["model"])
+        return (
+            model,
+            config,
+            metadata,
+            payload.get("optimizer"),
+            payload.get("scheduler"),
+        )
+
+    if target.suffix == ".safetensors":
+        model, config = _load_legacy_model(target)
+        metadata = {"checkpoint_format": "coolrl.omok.legacy_weights.v1"}
+        raw_metadata_path = checkpoint_metadata_path(target)
+        if raw_metadata_path.exists():
+            raw = json.loads(raw_metadata_path.read_text(encoding="utf-8"))
+            metadata.update(raw.get("metadata", {}))
+            if "config" in raw:
+                config = config_from_dict(raw["config"])
+        metadata["torch_version"] = torch.__version__
+        return model, config, metadata, None, None
+
+    raise ValueError(f"unsupported checkpoint extension: {target.suffix!r}")
+
+
+def list_checkpoints(directory: str | Path) -> list[Path]:
+    root = Path(directory)
+    if not root.exists():
+        return []
+    checkpoint_files = sorted(
+        path
+        for path in root.iterdir()
+        if path.is_file()
+        and path.suffix in {".pt", ".safetensors"}
+        and path.name not in {"trainer_state.pt", "optimizer.safetensors"}
+    )
+    preferred = []
+    for name in ("best.pt", "latest.pt", "best.safetensors", "latest.safetensors"):
+        for path in checkpoint_files:
+            if path.name == name:
+                preferred.append(path)
+                break
+    remainder = [path for path in checkpoint_files if path not in preferred]
+    return remainder + preferred
+
+
+def save_trainer_state(
+    directory: str | Path,
+    metadata: dict[str, Any],
+    replay_state: dict[str, Any],
+) -> None:
+    root = Path(directory)
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "trainer_state.json").write_text(
+        json.dumps(metadata, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    with (root / "replay.pkl").open("wb") as fh:
+        pickle.dump(replay_state, fh, protocol=pickle.HIGHEST_PROTOCOL)
+
+
+def load_trainer_state(directory: str | Path) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    root = Path(directory)
+    metadata_path = root / "trainer_state.json"
+    if not metadata_path.exists():
+        raise FileNotFoundError(metadata_path)
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    replay_path = root / "replay.pkl"
+    replay_state = None
+    if replay_path.exists():
+        with replay_path.open("rb") as fh:
+            replay_state = pickle.load(fh)
+    return metadata, replay_state

--- a/src/coolrl/omok15/config.py
+++ b/src/coolrl/omok15/config.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import os
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass(slots=True)
+class RulesConfig:
+    board_size: int = 15
+    exactly_five: bool = False
+
+    def __post_init__(self) -> None:
+        if self.board_size != 15:
+            raise ValueError("only 15x15 Omok is supported in coolrl.omok15")
+
+
+@dataclass(slots=True)
+class NetworkConfig:
+    input_planes: int = 4
+    channels: int = 32
+    blocks: int = 2
+    value_hidden: int = 64
+    se_reduction: int = 8
+
+
+@dataclass(slots=True)
+class SelfPlayConfig:
+    mcts_backend: str = "python"
+    evaluator_backend: str = "torch"
+    games_per_iteration: int = 4
+    batch_size: int = 2
+    num_workers: int | str = 0
+    search_threads: int | str = 1
+    inference_batch_size: int = 256
+    inference_wait_ms: float = 1.0
+    temperature_moves: int = 6
+    temperature_end: float = 0.0
+    dirichlet_alpha: float = 0.25
+    dirichlet_epsilon: float = 0.20
+    c_puct: float = 1.6
+    virtual_loss: float = 1.0
+    leaves_per_batch: int = 1
+    simulation_ramp_iterations: int | None = None
+    candidate_mix_fraction: float = 0.0
+    mixed_iterations_after_promotion: int = 0
+    simulation_schedule: list[dict[str, float | int]] = field(
+        default_factory=lambda: [{"fraction": 0.0, "simulations": 16}]
+    )
+
+    def resolved_num_workers(self) -> tuple[int, bool]:
+        value = self.num_workers
+        if isinstance(value, str):
+            token = value.strip().lower()
+            if token == "auto":
+                return max(1, os.cpu_count() or 1), True
+            try:
+                return max(0, int(token)), False
+            except ValueError as exc:
+                raise ValueError(f"unsupported selfplay.num_workers: {value!r}") from exc
+        return max(0, int(value)), False
+
+    def resolved_search_threads(self) -> tuple[int, bool]:
+        value = self.search_threads
+        if isinstance(value, str):
+            token = value.strip().lower()
+            if token == "auto":
+                return max(1, os.cpu_count() or 1), True
+            try:
+                return max(1, int(token)), False
+            except ValueError as exc:
+                raise ValueError(f"unsupported selfplay.search_threads: {value!r}") from exc
+        return max(1, int(value)), False
+
+
+@dataclass(slots=True)
+class OptimizationConfig:
+    batch_size: int = 32
+    updates_per_iteration: int = 8
+    learning_rate: float = 1.0e-3
+    min_learning_rate: float = 1.0e-4
+    weight_decay: float = 1.0e-4
+    grad_clip: float = 0.0
+    replay_capacity: int = 4096
+    warmup_games: int = 4
+    policy_loss_weight: float = 1.0
+    value_loss_weight: float = 1.0
+    value_discount: float = 1.0
+    recency_temperature: float = 0.0
+
+
+@dataclass(slots=True)
+class ArenaConfig:
+    games: int = 4
+    simulations: int = 16
+    accept_win_rate: float = 0.55
+    min_white_win_rate: float = 0.0
+    bootstrap_games: int = 2
+    bootstrap_simulations: int = 16
+    bootstrap_accept_win_rate: float = 0.0
+    bootstrap_min_white_win_rate: float = 0.0
+
+
+@dataclass(slots=True)
+class CheckpointConfig:
+    directory: str = "checkpoints/omok15_default"
+    save_every_iteration: bool = True
+    save_iteration_interval: int = 1
+    progress_interval_batches: int = 4
+    progress_interval_seconds: float = 30.0
+
+
+@dataclass(slots=True)
+class RunConfig:
+    experiment_name: str = "omok15_15x15"
+    seed: int = 17
+    max_hours: float | None = None
+    max_iterations: int | None = None
+    device: str = "auto"
+    use_amp: bool = False
+    rules: RulesConfig = field(default_factory=RulesConfig)
+    network: NetworkConfig = field(default_factory=NetworkConfig)
+    selfplay: SelfPlayConfig = field(default_factory=SelfPlayConfig)
+    optimization: OptimizationConfig = field(default_factory=OptimizationConfig)
+    arena: ArenaConfig = field(default_factory=ArenaConfig)
+    checkpoint: CheckpointConfig = field(default_factory=CheckpointConfig)
+
+    @property
+    def checkpoint_dir(self) -> Path:
+        return Path(self.checkpoint.directory)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _merge_dict(base: dict[str, Any], update: dict[str, Any]) -> dict[str, Any]:
+    result = dict(base)
+    for key, value in update.items():
+        if isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = _merge_dict(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def _to_dataclass(cfg: dict[str, Any]) -> RunConfig:
+    raw_max_hours = cfg.get("max_hours", None)
+    raw_max_iterations = cfg.get("max_iterations", None)
+    return RunConfig(
+        experiment_name=str(cfg.get("experiment_name", "omok15_15x15")),
+        seed=int(cfg.get("seed", 17)),
+        max_hours=None if raw_max_hours is None else float(raw_max_hours),
+        max_iterations=None if raw_max_iterations is None else int(raw_max_iterations),
+        device=str(cfg.get("device", "auto")),
+        use_amp=bool(cfg.get("use_amp", False)),
+        rules=RulesConfig(**cfg.get("rules", {})),
+        network=NetworkConfig(**cfg.get("network", {})),
+        selfplay=SelfPlayConfig(**cfg.get("selfplay", {})),
+        optimization=OptimizationConfig(**cfg.get("optimization", {})),
+        arena=ArenaConfig(**cfg.get("arena", {})),
+        checkpoint=CheckpointConfig(**cfg.get("checkpoint", {})),
+    )
+
+
+def load_config(path: str | Path | None) -> RunConfig:
+    default = RunConfig()
+    if path is None:
+        return default
+    raw = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+    merged = _merge_dict(default.to_dict(), raw)
+    return _to_dataclass(merged)
+
+
+def config_from_dict(payload: dict[str, Any]) -> RunConfig:
+    return _to_dataclass(_merge_dict(RunConfig().to_dict(), payload))

--- a/src/coolrl/omok15/convert_onnx.py
+++ b/src/coolrl/omok15/convert_onnx.py
@@ -1,0 +1,295 @@
+"""
+Convert ONNX omok checkpoints to safetensors format for use with coolrl.omok.gui.
+
+Requires the ``onnx`` package (not a normal project dependency):
+
+    uv run --with onnx python -m coolrl.omok.convert_onnx \\
+        --source /path/to/omokai/web/models \\
+        --output checkpoints/omokai_converted
+
+Background
+----------
+PyTorch fuses Conv + BatchNorm into a single Conv node during ONNX export,
+so the ONNX file contains fused conv weights (with BN scale absorbed) and
+no separate BN tensors. The Omok model applies Conv then BN
+separately, so we reconstruct identity BN parameters:
+
+    running_mean  = 0
+    running_var   = 1 - eps           (so sqrt(running_var + eps) == 1 exactly)
+    weight        = 1
+    bias          = fused_conv_bias   (the only contribution that remains)
+    num_batches_tracked = 0
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# ONNX extraction helpers
+# ---------------------------------------------------------------------------
+
+def _require_onnx():
+    try:
+        import onnx  # noqa: F401
+    except ImportError:
+        print(
+            "The 'onnx' package is required but not installed.\n"
+            "Run the script with:\n"
+            "  uv run --with onnx python -m coolrl.omok.convert_onnx ...",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def _load_onnx_initializers(onnx_path: Path) -> dict[str, np.ndarray]:
+    import onnx
+    import onnx.numpy_helper
+
+    model = onnx.load(str(onnx_path))
+    return {init.name: onnx.numpy_helper.to_array(init) for init in model.graph.initializer}
+
+
+# ---------------------------------------------------------------------------
+# State dict construction
+# ---------------------------------------------------------------------------
+
+_BN_EPS = 1e-5  # default eps for BatchNorm2d
+
+
+def _identity_bn(out_channels: int, fused_bias: np.ndarray) -> dict[str, np.ndarray]:
+    """Identity BN parameters that simply add the fused conv bias."""
+    return {
+        "running_mean": np.zeros(out_channels, dtype=np.float32),
+        "running_var": np.full(out_channels, 1.0 - _BN_EPS, dtype=np.float32),
+        "weight": np.ones(out_channels, dtype=np.float32),
+        "bias": fused_bias.astype(np.float32),
+        "num_batches_tracked": np.array(0, dtype=np.int64),
+    }
+
+
+def _build_state_dict(
+    raw: dict[str, np.ndarray],
+    channels: int,
+    blocks: int,
+) -> dict[str, np.ndarray]:
+    """Map ONNX initializer names to Omok PolicyValueNet state dict keys.
+
+    Fused conv initializers have opaque ``onnx::Conv_NNN`` names.  They appear
+    in graph order: stem, tower[0].conv1, tower[0].conv2, ..., policy, value.
+    Within each pair, the higher-dimensional tensor is the weight and the 1-D
+    tensor is the bias.  Some ONNX exports omit zero biases (e.g. at iteration
+    0), so we fall back to zeros when a bias is missing.
+    """
+    # --- pair (weight, bias) from sorted onnx::Conv_* entries -------------
+    fused_keys = sorted(
+        [k for k in raw if k.startswith("onnx::Conv_")],
+        key=lambda k: int(k.rsplit("_", 1)[-1]),
+    )
+
+    fused: list[tuple[np.ndarray, np.ndarray]] = []
+    i = 0
+    while i < len(fused_keys):
+        w = raw[fused_keys[i]]
+        if w.ndim < 2:
+            raise ValueError(f"Unexpected 1-D initializer before a weight: {fused_keys[i]}")
+        out_channels = w.shape[0]
+        # Check if the next entry is the matching bias (ndim==1)
+        if i + 1 < len(fused_keys) and raw[fused_keys[i + 1]].ndim == 1:
+            b = raw[fused_keys[i + 1]]
+            i += 2
+        else:
+            b = np.zeros(out_channels, dtype=np.float32)
+            i += 1
+        fused.append((w, b))
+
+    expected_fused = 1 + blocks * 2 + 2  # stem + tower + policy + value
+    if len(fused) != expected_fused:
+        raise ValueError(
+            f"Expected {expected_fused} fused conv pairs, got {len(fused)}."
+        )
+
+    state: dict[str, np.ndarray] = {}
+
+    def _place_conv_bn(w: np.ndarray, b: np.ndarray, conv_key: str, bn_prefix: str, out_ch: int) -> None:
+        state[conv_key] = w.astype(np.float32)
+        for suffix, arr in _identity_bn(out_ch, b).items():
+            state[f"{bn_prefix}.{suffix}"] = arr
+
+    idx = 0
+
+    # stem
+    _place_conv_bn(fused[idx][0], fused[idx][1], "stem_conv.weight", "stem_bn", channels)
+    idx += 1
+
+    # residual tower
+    for i in range(blocks):
+        _place_conv_bn(fused[idx][0], fused[idx][1], f"tower.{i}.conv1.weight", f"tower.{i}.bn1", channels)
+        idx += 1
+        _place_conv_bn(fused[idx][0], fused[idx][1], f"tower.{i}.conv2.weight", f"tower.{i}.bn2", channels)
+        idx += 1
+
+    # policy head conv
+    _place_conv_bn(fused[idx][0], fused[idx][1], "policy_conv.weight", "policy_bn", 2)
+    idx += 1
+
+    # value head conv
+    _place_conv_bn(fused[idx][0], fused[idx][1], "value_conv.weight", "value_bn", 1)
+    idx += 1
+
+    # --- SE blocks (named initializers) ------------------------------------
+    for i in range(blocks):
+        for src, dst in [
+            (f"tower.{i}.se.fc.1.weight", f"tower.{i}.se.fc1.weight"),
+            (f"tower.{i}.se.fc.1.bias",   f"tower.{i}.se.fc1.bias"),
+            (f"tower.{i}.se.fc.3.weight", f"tower.{i}.se.fc2.weight"),
+            (f"tower.{i}.se.fc.3.bias",   f"tower.{i}.se.fc2.bias"),
+        ]:
+            state[dst] = raw[src].astype(np.float32)
+
+    # --- FC heads (named initializers) ------------------------------------
+    for src, dst in [
+        ("policy_head.4.weight", "policy_fc.weight"),
+        ("policy_head.4.bias",   "policy_fc.bias"),
+        ("value_head.4.weight",  "value_fc1.weight"),
+        ("value_head.4.bias",    "value_fc1.bias"),
+        ("value_head.6.weight",  "value_fc2.weight"),
+        ("value_head.6.bias",    "value_fc2.bias"),
+    ]:
+        state[dst] = raw[src].astype(np.float32)
+
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Config / sidecar helpers
+# ---------------------------------------------------------------------------
+
+def _infer_arch(raw: dict[str, np.ndarray]) -> tuple[int, int]:
+    """Infer value_hidden and se_reduction from tensor shapes."""
+    value_hidden = int(raw["value_head.4.weight"].shape[0])
+
+    # SE fc1 shape: [se_hidden, channels]
+    se_fc1_key = next(k for k in raw if re.match(r"tower\.\d+\.se\.fc\.1\.weight", k))
+    se_hidden = int(raw[se_fc1_key].shape[0])
+    channels = int(raw[se_fc1_key].shape[1])
+    se_reduction = channels // se_hidden
+
+    return value_hidden, se_reduction
+
+
+def _make_sidecar(entry: dict, value_hidden: int, se_reduction: int) -> dict:
+    return {
+        "config": {
+            "experiment_name": "omokai_converted",
+            "seed": 0,
+            "device": "auto",
+            "rules": {
+                "board_size": entry["board_size"],
+                "exactly_five": entry["exactly_five"],
+            },
+            "network": {
+                "input_planes": entry["input_planes"],
+                "channels": entry["channels"],
+                "blocks": entry["blocks"],
+                "value_hidden": value_hidden,
+                "se_reduction": se_reduction,
+            },
+        },
+        "metadata": {**entry.get("metadata", {}), "source": "omokai_onnx"},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Per-checkpoint conversion
+# ---------------------------------------------------------------------------
+
+def _convert_one(
+    onnx_path: Path,
+    out_path: Path,
+    entry: dict,
+    value_hidden: int,
+    se_reduction: int,
+    *,
+    verbose: bool = True,
+) -> None:
+    from safetensors.numpy import save_file
+
+    raw = _load_onnx_initializers(onnx_path)
+    numpy_state = _build_state_dict(raw, entry["channels"], entry["blocks"])
+
+    save_file(numpy_state, str(out_path), metadata={"format": "coolrl.omok.legacy_weights.v1"})
+
+    sidecar = _make_sidecar(entry, value_hidden, se_reduction)
+    out_path.with_suffix(".json").write_text(
+        json.dumps(sidecar, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    if verbose:
+        iteration = entry.get("metadata", {}).get("iteration", "?")
+        print(f"  {onnx_path.name} -> {out_path.name}  (iter={iteration})")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def convert(source: Path, output: Path) -> None:
+    _require_onnx()
+
+    manifest_path = source / "manifest.json"
+    if not manifest_path.exists():
+        print(f"manifest.json not found in {source}", file=sys.stderr)
+        sys.exit(1)
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    entries: list[dict] = manifest["checkpoints"]
+
+    if not entries:
+        print("No checkpoints in manifest.", file=sys.stderr)
+        sys.exit(1)
+
+    output.mkdir(parents=True, exist_ok=True)
+
+    # Infer architecture parameters from the first available ONNX file.
+    first_onnx = source / entries[0]["file"]
+    raw0 = _load_onnx_initializers(first_onnx)
+    value_hidden, se_reduction = _infer_arch(raw0)
+    print(f"Inferred: value_hidden={value_hidden}, se_reduction={se_reduction}")
+    print(f"Converting {len(entries)} checkpoint(s) to {output} ...")
+
+    for entry in entries:
+        onnx_path = source / entry["file"]
+        if not onnx_path.exists():
+            print(f"  [skip] {onnx_path.name} not found")
+            continue
+        out_name = entry["name"] + ".safetensors"
+        _convert_one(onnx_path, output / out_name, entry, value_hidden, se_reduction)
+
+    print("Done.")
+
+
+def _build_argparser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Convert ONNX omok checkpoints to safetensors.",
+        epilog="Run with: uv run --with onnx python -m coolrl.omok.convert_onnx ...",
+    )
+    p.add_argument("--source", required=True, help="Directory containing .onnx files and manifest.json")
+    p.add_argument("--output", required=True, help="Destination directory for .safetensors files")
+    return p
+
+
+def main() -> None:
+    args = _build_argparser().parse_args()
+    convert(Path(args.source), Path(args.output))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/coolrl/omok15/device.py
+++ b/src/coolrl/omok15/device.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import torch
+
+
+def configure_device(requested: str = "auto") -> str:
+    name = requested.strip().upper()
+    if name == "AUTO":
+        if torch.cuda.is_available():
+            return "CUDA"
+        if torch.backends.mps.is_available():
+            return "METAL"
+        return "CPU"
+    if name == "CUDA":
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA requested but torch.cuda is unavailable")
+        return "CUDA"
+    if name in {"METAL", "GPU"}:
+        if not torch.backends.mps.is_available():
+            raise RuntimeError("Metal/MPS requested but torch.backends.mps is unavailable")
+        return "METAL"
+    if name == "CPU":
+        return "CPU"
+    raise ValueError(f"unsupported torch device: {requested!r}")

--- a/src/coolrl/omok15/evaluator.py
+++ b/src/coolrl/omok15/evaluator.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import numpy as np
+
+from .board import GameState
+
+
+class Evaluator:
+    def evaluate(self, states: list[GameState]) -> tuple[np.ndarray, np.ndarray]:
+        raise NotImplementedError
+
+    def effective_batch_size(self, batch_size: int) -> int:
+        return batch_size
+
+    def close(self) -> None:
+        return None

--- a/src/coolrl/omok15/export_onnx.py
+++ b/src/coolrl/omok15/export_onnx.py
@@ -1,0 +1,123 @@
+"""
+Export checkpoints to ONNX for browser inference.
+
+Usage:
+
+    uv run --with torch --with onnx python -m coolrl.omok.export_onnx \
+        --checkpoint checkpoints/omok_full_cuda/latest.pt \
+        --output exports/best.onnx
+
+    uv run --with torch --with onnx python -m coolrl.omok.export_onnx \
+        --checkpoint checkpoints/omok_full_cuda \
+        --output exports/omok_full_cuda
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import json
+
+
+def _require_torch() -> None:
+    try:
+        import torch  # noqa: F401
+    except ImportError:
+        print(
+            "PyTorch is required but not installed.\n"
+            "Run with: uv run --with torch --with onnx python -m coolrl.omok.export_onnx ...",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def export_one(ckpt_path: Path, out_path: Path, *, verbose: bool = True) -> None:
+    import torch
+
+    from .checkpoint import checkpoint_metadata_path, load_checkpoint
+    from .config import config_from_dict
+
+    model, config, metadata, _, _ = load_checkpoint(ckpt_path)
+    model.eval()
+    model.cpu()
+
+    target = checkpoint_metadata_path(ckpt_path)
+    sidecar = {}
+    if target.exists():
+        sidecar = json.loads(target.read_text(encoding="utf-8"))
+    out_config = sidecar.get("config", None)
+    if not out_config:
+        out_config = config.to_dict()
+    cfg = config_from_dict(out_config)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    dummy = torch.zeros(1, cfg.network.input_planes, cfg.rules.board_size, cfg.rules.board_size)
+    torch.onnx.export(
+        model,
+        dummy,
+        str(out_path),
+        input_names=["input"],
+        output_names=["policy_logits", "value"],
+        dynamic_axes={
+            "input": {0: "batch"},
+            "policy_logits": {0: "batch"},
+            "value": {0: "batch"},
+        },
+        opset_version=17,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+
+    if verbose:
+        size_kb = out_path.stat().st_size / 1024
+        iteration = metadata.get("iteration", "?")
+        print(f"  {ckpt_path.name} -> {out_path.name}  ({size_kb:.0f} KB, iter={iteration})")
+
+
+def export_directory(ckpt_dir: Path, out_dir: Path) -> None:
+    from .checkpoint import list_checkpoints
+
+    checkpoints = list_checkpoints(ckpt_dir)
+    if not checkpoints:
+        print(f"No checkpoints found in {ckpt_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    print(f"Exporting {len(checkpoints)} checkpoint(s) to {out_dir} ...")
+
+    for ckpt in checkpoints:
+        out_path = out_dir / ckpt.with_suffix(".onnx").name
+        try:
+            export_one(ckpt, out_path)
+        except Exception as exc:
+            print(f"  [skip] {ckpt.name}: {exc}")
+
+
+def _build_argparser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Export checkpoints to ONNX.",
+        epilog="Run with: uv run --with torch --with onnx python -m coolrl.omok.export_onnx ...",
+    )
+    p.add_argument("--checkpoint", required=True, help="Path to checkpoint file or directory")
+    p.add_argument("--output", required=True, help="Output .onnx file path or directory")
+    return p
+
+
+def main() -> None:
+    _require_torch()
+    args = _build_argparser().parse_args()
+    src = Path(args.checkpoint)
+    dst = Path(args.output)
+
+    if src.is_dir():
+        export_directory(src, dst)
+    else:
+        if dst.suffix != ".onnx":
+            dst = dst.with_suffix(".onnx")
+        export_one(src, dst)
+        print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/coolrl/omok15/features.py
+++ b/src/coolrl/omok15/features.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import numpy as np
+
+from .board import GameState
+
+
+def states_to_feature_planes(states: list[GameState]) -> np.ndarray:
+    if not states:
+        raise ValueError("states must not be empty")
+    board_size = states[0].board_size
+    boards = np.stack([state.board for state in states], axis=0).astype(np.int8, copy=False)
+    to_play = np.fromiter((state.to_play for state in states), dtype=np.int8, count=len(states))
+    last_actions = np.fromiter(
+        (-1 if state.last_action is None else state.last_action for state in states),
+        dtype=np.int32,
+        count=len(states),
+    )
+    return encode_feature_planes_batch(boards, to_play, last_actions, board_size)
+
+
+def encode_feature_planes_batch(
+    boards: np.ndarray,
+    to_play: np.ndarray,
+    last_actions: np.ndarray,
+    board_size: int | None = None,
+) -> np.ndarray:
+    if boards.ndim != 3:
+        raise ValueError("boards must have shape [batch, board_size, board_size]")
+    if board_size is None:
+        board_size = int(boards.shape[-1])
+
+    own = (boards == to_play[:, None, None]).astype(np.float32, copy=False)
+    opp = (boards == -to_play[:, None, None]).astype(np.float32, copy=False)
+    last = np.zeros_like(own, dtype=np.float32)
+    valid_last = last_actions >= 0
+    if np.any(valid_last):
+        rows = last_actions[valid_last] // board_size
+        cols = last_actions[valid_last] % board_size
+        last[np.flatnonzero(valid_last), rows, cols] = 1.0
+    color_value = (to_play == 1).astype(np.float32)[:, None, None]
+    color = np.broadcast_to(color_value, own.shape)
+
+    planes = np.empty((boards.shape[0], 4, board_size, board_size), dtype=np.float32)
+    planes[:, 0] = own
+    planes[:, 1] = opp
+    planes[:, 2] = last
+    planes[:, 3] = color
+    return planes
+
+
+def apply_symmetry_batch(planes: np.ndarray, policy: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    if planes.ndim != 4:
+        raise ValueError("planes must have shape [batch, channels, board_size, board_size]")
+    if policy.ndim != 2:
+        raise ValueError("policy must have shape [batch, action_size]")
+
+    batch_size = planes.shape[0]
+    board_size = planes.shape[-1]
+    policy_grid = policy.reshape(batch_size, board_size, board_size)
+    transforms = np.random.randint(8, size=batch_size)
+    transformed_planes = np.empty_like(planes)
+    transformed_policy = np.empty_like(policy_grid)
+
+    for transform in range(8):
+        mask = transforms == transform
+        if not np.any(mask):
+            continue
+        planes_slice = planes[mask]
+        policy_slice = policy_grid[mask]
+        mirror = transform >= 4
+        rotate = transform - 4 if mirror else transform
+        if mirror:
+            planes_slice = planes_slice[:, :, :, ::-1]
+            policy_slice = policy_slice[:, :, ::-1]
+        if rotate:
+            planes_slice = np.rot90(planes_slice, rotate, axes=(-2, -1))
+            policy_slice = np.rot90(policy_slice, rotate, axes=(-2, -1))
+        transformed_planes[mask] = np.ascontiguousarray(planes_slice)
+        transformed_policy[mask] = np.ascontiguousarray(policy_slice)
+
+    return transformed_planes, transformed_policy.reshape(batch_size, -1)
+

--- a/src/coolrl/omok15/mcts.py
+++ b/src/coolrl/omok15/mcts.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from .board import GameState
+from .evaluator import Evaluator
+from .mcts_types import SearchResult
+
+
+@dataclass(slots=True)
+class TreeNode:
+    to_play: int
+    prior: float = 0.0
+    visit_count: int = 0
+    value_sum: float = 0.0
+    children: dict[int, "TreeNode"] = field(default_factory=dict)
+    expanded: bool = False
+
+    def value(self) -> float:
+        return 0.0 if self.visit_count == 0 else self.value_sum / self.visit_count
+
+
+class MCTS:
+    def __init__(
+        self,
+        c_puct: float,
+        dirichlet_alpha: float,
+        dirichlet_epsilon: float,
+        evaluator: Evaluator,
+        search_threads: int = 1,
+        virtual_loss: float = 1.0,
+    ) -> None:
+        self.c_puct = c_puct
+        self.dirichlet_alpha = dirichlet_alpha
+        self.dirichlet_epsilon = dirichlet_epsilon
+        self.evaluator = evaluator
+        self.search_threads = max(1, int(search_threads))
+        self.virtual_loss = float(virtual_loss)
+
+    def search_batch(
+        self,
+        states: list[GameState],
+        num_simulations: int,
+        temperature: list[float],
+        add_noise: bool,
+        roots: list[TreeNode | None] | None = None,
+        leaves_per_batch: int = 1,
+    ) -> list[SearchResult]:
+        if roots is None:
+            roots = [None] * len(states)
+        if len(roots) != len(states):
+            raise ValueError("roots and states must have the same length")
+
+        active_roots = [
+            root if root is not None else TreeNode(to_play=state.to_play)
+            for state, root in zip(states, roots, strict=True)
+        ]
+        root_values = np.zeros(len(states), dtype=np.float32)
+        init_indices: list[int] = []
+        init_states: list[GameState] = []
+        for idx, (state, root) in enumerate(zip(states, active_roots, strict=True)):
+            if state.terminal:
+                continue
+            if not root.expanded:
+                init_indices.append(idx)
+                init_states.append(state)
+            elif root.visit_count > 0:
+                root_values[idx] = float(root.value())
+        if init_states:
+            priors, values = self._evaluate(init_states)
+            for offset, idx in enumerate(init_indices):
+                self._expand(active_roots[idx], states[idx], priors[offset])
+                root_values[idx] = float(values[offset])
+
+        for state, root in zip(states, active_roots, strict=True):
+            if add_noise and not state.terminal:
+                self._apply_root_noise(root)
+
+        leaves_per_batch = max(1, int(leaves_per_batch))
+        sims_done = 0
+        while sims_done < num_simulations:
+            leaves_this_round = min(leaves_per_batch, num_simulations - sims_done)
+            pending_states: list[GameState] = []
+            pending_nodes: list[TreeNode] = []
+            pending_paths: list[list[TreeNode]] = []
+
+            for root, root_state in zip(active_roots, states, strict=True):
+                if root_state.terminal:
+                    continue
+                for _ in range(leaves_this_round):
+                    state = root_state.clone()
+                    node = root
+                    path = [node]
+                    while node.expanded and node.children and not state.terminal:
+                        action, node = self._select_child(node)
+                        state.apply_action(action)
+                        path.append(node)
+                    if state.terminal:
+                        self._backup(path, state.outcome_for_player(state.to_play))
+                        continue
+                    self._apply_virtual_loss(path)
+                    pending_states.append(state)
+                    pending_nodes.append(node)
+                    pending_paths.append(path)
+
+            sims_done += leaves_this_round
+            if not pending_states:
+                continue
+
+            batch_priors, batch_values = self._evaluate(pending_states)
+            for state, node, path, prior, value in zip(
+                pending_states, pending_nodes, pending_paths, batch_priors, batch_values, strict=True
+            ):
+                self._revert_virtual_loss(path)
+                self._expand(node, state, prior)
+                self._backup(path, float(value))
+
+        results: list[SearchResult] = []
+        for root, state, root_value, temp in zip(active_roots, states, root_values, temperature, strict=True):
+            counts = np.zeros(state.action_size, dtype=np.float32)
+            for action, child in root.children.items():
+                counts[action] = float(child.visit_count)
+            if counts.sum() == 0:
+                legal = state.legal_moves().astype(np.float32)
+                counts = legal / legal.sum()
+            else:
+                counts /= counts.sum()
+            action = sample_action_from_policy(counts, temp)
+            next_root = None if state.terminal else root.children.get(action)
+            results.append(SearchResult(action=action, visit_policy=counts, root_value=float(root_value), next_root=next_root))
+        return results
+
+    def _select_child(self, node: TreeNode) -> tuple[int, TreeNode]:
+        sqrt_visits = np.sqrt(max(1, node.visit_count))
+        best_action = -1
+        best_score = -float("inf")
+        best_child: TreeNode | None = None
+        for action, child in node.children.items():
+            q = -child.value()
+            u = self.c_puct * child.prior * sqrt_visits / (1 + child.visit_count)
+            score = q + u
+            if score > best_score:
+                best_score = score
+                best_action = action
+                best_child = child
+        if best_child is None:
+            raise RuntimeError("tree node has no child to select")
+        return best_action, best_child
+
+    def _expand(self, node: TreeNode, state: GameState, priors: np.ndarray) -> None:
+        legal = state.legal_moves()
+        masked_priors = np.zeros_like(priors, dtype=np.float32)
+        masked_priors[legal] = priors[legal]
+        total = float(masked_priors.sum())
+        if total <= 0.0:
+            masked_priors[legal] = 1.0 / max(1, int(legal.sum()))
+        else:
+            masked_priors /= total
+        node.children = {
+            action: TreeNode(to_play=-state.to_play, prior=float(masked_priors[action]))
+            for action in np.flatnonzero(legal)
+        }
+        node.expanded = True
+
+    def _backup(self, path: list[TreeNode], value: float) -> None:
+        for node in reversed(path):
+            node.visit_count += 1
+            node.value_sum += value
+            value = -value
+
+    def _apply_virtual_loss(self, path: list[TreeNode]) -> None:
+        for node in path:
+            node.visit_count += 1
+            node.value_sum += self.virtual_loss
+
+    def _revert_virtual_loss(self, path: list[TreeNode]) -> None:
+        for node in path:
+            node.visit_count -= 1
+            node.value_sum -= self.virtual_loss
+
+    def _apply_root_noise(self, root: TreeNode) -> None:
+        if not root.children or self.dirichlet_alpha <= 0.0 or self.dirichlet_epsilon <= 0.0:
+            return
+        actions = list(root.children)
+        noise = np.random.dirichlet([self.dirichlet_alpha] * len(actions))
+        for action, n in zip(actions, noise, strict=True):
+            child = root.children[action]
+            child.prior = (1.0 - self.dirichlet_epsilon) * child.prior + self.dirichlet_epsilon * float(n)
+
+    def _evaluate(self, states: list[GameState]) -> tuple[np.ndarray, np.ndarray]:
+        return self.evaluator.evaluate(states)
+
+
+def sample_action_from_policy(policy: np.ndarray, temperature: float) -> int:
+    if temperature <= 1.0e-6:
+        return int(np.argmax(policy))
+    adjusted = np.power(np.maximum(policy, 1.0e-8), 1.0 / temperature)
+    adjusted /= adjusted.sum()
+    return int(np.random.choice(np.arange(policy.size), p=adjusted))

--- a/src/coolrl/omok15/mcts_backend.py
+++ b/src/coolrl/omok15/mcts_backend.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Literal
+
+
+MctsBackend = Literal["python"]
+
+
+def resolve_mcts_backend(name: str):
+    backend = name.strip().lower()
+    if backend == "python":
+        from . import mcts
+
+        return mcts
+    raise ValueError(
+        f"unsupported selfplay.mcts_backend: {name!r} (coolrl.omok15 currently supports only 'python')"
+    )

--- a/src/coolrl/omok15/mcts_types.py
+++ b/src/coolrl/omok15/mcts_types.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import numpy as np
+
+from .board import GameState
+
+
+@dataclass(slots=True)
+class SearchResult:
+    action: int
+    visit_policy: np.ndarray
+    root_value: float
+    next_root: object | None = None
+
+
+class MCTSBackend(Protocol):
+    def search_batch(
+        self,
+        states: list[GameState],
+        num_simulations: int,
+        temperature: list[float],
+        add_noise: bool,
+        roots: list[Any | None] | None = None,
+        leaves_per_batch: int = 1,
+    ) -> list[SearchResult]: ...

--- a/src/coolrl/omok15/metrics.py
+++ b/src/coolrl/omok15/metrics.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Callable, TypeVar
+
+import numpy as np
+
+from .board import GameState
+from .evaluator import Evaluator
+
+
+T = TypeVar("T")
+
+
+def _round_seconds(value: float) -> float:
+    return round(value, 6)
+
+
+@dataclass(slots=True)
+class EvaluatorMetrics:
+    calls: int = 0
+    positions: int = 0
+    padded_positions: int = 0
+    seconds: float = 0.0
+    max_batch: int = 0
+    max_bucket: int = 0
+    bucket_counts: dict[int, int] = field(default_factory=dict)
+
+    def record(self, batch_size: int, effective_batch_size: int, seconds: float) -> None:
+        bucket = max(1, effective_batch_size)
+        self.calls += 1
+        self.positions += batch_size
+        self.padded_positions += bucket
+        self.seconds += seconds
+        self.max_batch = max(self.max_batch, batch_size)
+        self.max_bucket = max(self.max_bucket, bucket)
+        self.bucket_counts[bucket] = self.bucket_counts.get(bucket, 0) + 1
+
+    @property
+    def avg_batch(self) -> float:
+        return 0.0 if self.calls == 0 else self.positions / self.calls
+
+    @property
+    def avg_seconds(self) -> float:
+        return 0.0 if self.calls == 0 else self.seconds / self.calls
+
+    @property
+    def pad_ratio(self) -> float:
+        return 0.0 if self.positions == 0 else self.padded_positions / self.positions
+
+
+@dataclass(slots=True)
+class SearchMetrics:
+    calls: int = 0
+    states: int = 0
+    simulations: int = 0
+    requested_leaves: int = 0
+    seconds: float = 0.0
+    max_states: int = 0
+    max_simulations: int = 0
+    max_leaves_per_batch: int = 0
+
+    def record(self, states: int, simulations: int, leaves_per_batch: int, seconds: float) -> None:
+        self.calls += 1
+        self.states += states
+        self.simulations += simulations
+        self.requested_leaves += states * simulations
+        self.seconds += seconds
+        self.max_states = max(self.max_states, states)
+        self.max_simulations = max(self.max_simulations, simulations)
+        self.max_leaves_per_batch = max(self.max_leaves_per_batch, leaves_per_batch)
+
+    @property
+    def avg_states(self) -> float:
+        return 0.0 if self.calls == 0 else self.states / self.calls
+
+    @property
+    def avg_seconds(self) -> float:
+        return 0.0 if self.calls == 0 else self.seconds / self.calls
+
+
+@dataclass(slots=True)
+class TrainingMetrics:
+    updates: int = 0
+    samples: int = 0
+    sample_seconds: float = 0.0
+    forward_seconds: float = 0.0
+    loss_seconds: float = 0.0
+    backward_seconds: float = 0.0
+    optimizer_seconds: float = 0.0
+    sync_seconds: float = 0.0
+
+    def record(
+        self,
+        *,
+        batch_size: int,
+        sample_seconds: float,
+        forward_seconds: float,
+        loss_seconds: float,
+        backward_seconds: float,
+        optimizer_seconds: float,
+        sync_seconds: float,
+    ) -> None:
+        self.updates += 1
+        self.samples += batch_size
+        self.sample_seconds += sample_seconds
+        self.forward_seconds += forward_seconds
+        self.loss_seconds += loss_seconds
+        self.backward_seconds += backward_seconds
+        self.optimizer_seconds += optimizer_seconds
+        self.sync_seconds += sync_seconds
+
+    @property
+    def total_measured_seconds(self) -> float:
+        return (
+            self.sample_seconds
+            + self.forward_seconds
+            + self.loss_seconds
+            + self.backward_seconds
+            + self.optimizer_seconds
+            + self.sync_seconds
+        )
+
+
+class IterationMetrics:
+    def __init__(self) -> None:
+        self.evaluator: dict[str, EvaluatorMetrics] = {}
+        self.search: dict[str, SearchMetrics] = {}
+        self.training = TrainingMetrics()
+
+    def timed_evaluator(self, phase: str, evaluator: Evaluator) -> "TimedEvaluator":
+        return TimedEvaluator(evaluator=evaluator, metrics=self, phase=phase)
+
+    def record_evaluator(self, phase: str, batch_size: int, effective_batch_size: int, seconds: float) -> None:
+        self.evaluator.setdefault(phase, EvaluatorMetrics()).record(batch_size, effective_batch_size, seconds)
+
+    def record_search(self, phase: str, states: int, simulations: int, leaves_per_batch: int, seconds: float) -> None:
+        self.search.setdefault(phase, SearchMetrics()).record(states, simulations, leaves_per_batch, seconds)
+
+    def time_search(
+        self,
+        phase: str,
+        states: int,
+        simulations: int,
+        leaves_per_batch: int,
+        callback: Callable[[], T],
+    ) -> T:
+        started = time.perf_counter()
+        try:
+            return callback()
+        finally:
+            self.record_search(phase, states, simulations, leaves_per_batch, time.perf_counter() - started)
+
+    def to_log_fields(self) -> dict[str, object]:
+        fields: dict[str, object] = {}
+        for phase, stats in sorted(self.search.items()):
+            prefix = f"search_{phase}"
+            fields[f"{prefix}_calls"] = stats.calls
+            fields[f"{prefix}_seconds"] = _round_seconds(stats.seconds)
+            fields[f"{prefix}_avg_seconds"] = _round_seconds(stats.avg_seconds)
+            fields[f"{prefix}_states"] = stats.states
+            fields[f"{prefix}_avg_states"] = round(stats.avg_states, 2)
+            fields[f"{prefix}_requested_leaves"] = stats.requested_leaves
+            fields[f"{prefix}_max_states"] = stats.max_states
+            fields[f"{prefix}_max_simulations"] = stats.max_simulations
+            fields[f"{prefix}_max_leaves_per_batch"] = stats.max_leaves_per_batch
+
+        for phase, stats in sorted(self.evaluator.items()):
+            prefix = f"eval_{phase}"
+            fields[f"{prefix}_calls"] = stats.calls
+            fields[f"{prefix}_seconds"] = _round_seconds(stats.seconds)
+            fields[f"{prefix}_avg_seconds"] = _round_seconds(stats.avg_seconds)
+            fields[f"{prefix}_positions"] = stats.positions
+            fields[f"{prefix}_padded_positions"] = stats.padded_positions
+            fields[f"{prefix}_pad_ratio"] = round(stats.pad_ratio, 4)
+            fields[f"{prefix}_avg_batch"] = round(stats.avg_batch, 2)
+            fields[f"{prefix}_max_batch"] = stats.max_batch
+            fields[f"{prefix}_max_bucket"] = stats.max_bucket
+            fields[f"{prefix}_bucket_counts"] = dict(sorted(stats.bucket_counts.items()))
+
+        train = self.training
+        fields.update(
+            {
+                "train_metric_updates": train.updates,
+                "train_metric_samples": train.samples,
+                "train_sample_seconds": _round_seconds(train.sample_seconds),
+                "train_forward_seconds": _round_seconds(train.forward_seconds),
+                "train_loss_seconds": _round_seconds(train.loss_seconds),
+                "train_backward_seconds": _round_seconds(train.backward_seconds),
+                "train_optimizer_seconds": _round_seconds(train.optimizer_seconds),
+                "train_sync_seconds": _round_seconds(train.sync_seconds),
+                "train_measured_seconds": _round_seconds(train.total_measured_seconds),
+            }
+        )
+        return fields
+
+
+class TimedEvaluator(Evaluator):
+    def __init__(self, evaluator: Evaluator, metrics: IterationMetrics, phase: str) -> None:
+        self.evaluator = evaluator
+        self.metrics = metrics
+        self.phase = phase
+
+    def evaluate(self, states: list[GameState]) -> tuple[np.ndarray, np.ndarray]:
+        started = time.perf_counter()
+        try:
+            return self.evaluator.evaluate(states)
+        finally:
+            batch_size = len(states)
+            self.metrics.record_evaluator(
+                self.phase,
+                batch_size,
+                self.evaluator.effective_batch_size(batch_size),
+                time.perf_counter() - started,
+            )
+
+    def evaluate_features(self, features: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        started = time.perf_counter()
+        try:
+            return self.evaluator.evaluate_features(features)  # type: ignore[attr-defined]
+        finally:
+            batch_size = int(features.shape[0])
+            self.metrics.record_evaluator(
+                self.phase,
+                batch_size,
+                self.evaluator.effective_batch_size(batch_size),
+                time.perf_counter() - started,
+            )
+
+    def close(self) -> None:
+        self.evaluator.close()

--- a/src/coolrl/omok15/openings.py
+++ b/src/coolrl/omok15/openings.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import random
+from typing import Iterable
+
+
+def build_opening_sequences(board_size: int, count: int) -> list[list[int]]:
+    center = board_size // 2
+    templates = [
+        (),
+        ((0, 0),),
+        ((0, 0), (0, 1)),
+        ((0, 0), (1, 0)),
+        ((0, 0), (1, 1)),
+        ((0, 0), (0, -1)),
+        ((0, 0), (-1, 0)),
+        ((0, 0), (1, -1)),
+        ((0, 0), (-1, 1)),
+        ((0, 0), (0, 1), (1, 0)),
+        ((0, 0), (1, 0), (0, 1)),
+        ((0, 0), (1, 1), (0, 1)),
+    ]
+    openings: list[list[int]] = []
+    for template in templates:
+        opening: list[int] = []
+        used_actions: set[int] = set()
+        valid = True
+        for dr, dc in template:
+            row = center + dr
+            col = center + dc
+            if not (0 <= row < board_size and 0 <= col < board_size):
+                valid = False
+                break
+            action = row * board_size + col
+            if action in used_actions:
+                valid = False
+                break
+            used_actions.add(action)
+            opening.append(action)
+        if valid:
+            openings.append(opening)
+    if not openings:
+        return [[] for _ in range(count)]
+    return [list(openings[index % len(openings)]) for index in range(count)]
+
+
+def apply_symmetry_to_action(action: int, board_size: int, transform: int) -> int:
+    row, col = divmod(action, board_size)
+    if transform >= 4:
+        col = board_size - 1 - col
+        transform -= 4
+    for _ in range(transform):
+        row, col = col, board_size - 1 - row
+    return row * board_size + col
+
+
+def transform_opening(opening: Iterable[int], board_size: int, transform: int) -> list[int]:
+    transformed = [apply_symmetry_to_action(action, board_size, transform) for action in opening]
+    if len(set(transformed)) != len(transformed):
+        return list(opening)
+    return transformed
+
+
+def sample_balanced_openings(board_size: int, count: int, rng: random.Random) -> list[list[int]]:
+    openings = build_opening_sequences(board_size, count)
+    transformed = [transform_opening(opening, board_size, rng.randrange(8)) for opening in openings]
+    rng.shuffle(transformed)
+    return transformed
+

--- a/src/coolrl/omok15/plot_metrics.py
+++ b/src/coolrl/omok15/plot_metrics.py
@@ -1,0 +1,402 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
+import numpy as np
+
+
+UNIFORM_POLICY_ENTROPY_15X15 = float(np.log(225))
+
+
+def load_metrics(path: Path) -> list[dict]:
+    rows = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            rows.append(json.loads(line))
+    return rows
+
+
+def trained_rows(rows: list[dict]) -> list[dict]:
+    return [r for r in rows if r.get("status") == "trained"]
+
+
+def normalized_iteration_rows(rows: list[dict]) -> list[dict]:
+    by_iteration: dict[int, dict] = {}
+    without_iteration: list[dict] = []
+
+    for row in rows:
+        iteration = row.get("iteration")
+        if isinstance(iteration, int):
+            by_iteration[iteration] = row
+        else:
+            without_iteration.append(row)
+
+    return without_iteration + [by_iteration[i] for i in sorted(by_iteration)]
+
+
+def field(rows: Sequence[dict], key: str, default: float = float("nan")) -> list[float]:
+    return [r.get(key, default) for r in rows]
+
+
+def summed_field(rows: Sequence[dict], *keys: str) -> list[float]:
+    values = []
+    for row in rows:
+        total = 0.0
+        seen = False
+        for key in keys:
+            value = row.get(key)
+            if value is not None:
+                total += float(value)
+                seen = True
+        values.append(total if seen else float("nan"))
+    return values
+
+
+def rate(numerators: Sequence[float], denominators: Sequence[float]) -> list[float]:
+    values = []
+    for numerator, denominator in zip(numerators, denominators, strict=False):
+        if denominator and np.isfinite(denominator) and denominator > 0:
+            values.append(float(numerator) / float(denominator))
+        else:
+            values.append(float("nan"))
+    return values
+
+
+def smooth_curve(x_values: Sequence[float], y_values: Sequence[float], points: int = 300) -> tuple[np.ndarray, np.ndarray]:
+    x = np.asarray(x_values, dtype=float)
+    y = np.asarray(y_values, dtype=float)
+    mask = np.isfinite(x) & np.isfinite(y)
+    x = x[mask]
+    y = y[mask]
+    if len(x) < 3:
+        return x, y
+
+    order = np.argsort(x)
+    x = x[order]
+    y = y[order]
+    unique_x, unique_idx = np.unique(x, return_index=True)
+    unique_y = y[unique_idx]
+    if len(unique_x) < 3:
+        return unique_x, unique_y
+
+    dense_x = np.linspace(unique_x[0], unique_x[-1], max(points, len(unique_x)))
+    dense_y = np.interp(dense_x, unique_x, unique_y)
+    window = max(3, min(9, len(unique_x) // 4 * 2 + 1))
+    if window >= 3:
+        kernel = np.ones(window, dtype=float) / window
+        pad = window // 2
+        padded = np.pad(dense_y, (pad, pad), mode="edge")
+        dense_y = np.convolve(padded, kernel, mode="valid")
+    return dense_x, dense_y
+
+
+def plot_curve(ax, x_values: Sequence[float], y_values: Sequence[float], **kwargs) -> None:
+    x, y = smooth_curve(x_values, y_values)
+    ax.plot(x, y, **kwargs)
+
+
+def iteration_tick_steps(axes: Sequence) -> tuple[int, int]:
+    max_iter = 0.0
+    for ax in axes:
+        right = ax.get_xlim()[1]
+        if np.isfinite(right):
+            max_iter = max(max_iter, right)
+
+    if max_iter <= 100:
+        return 10, 2
+    if max_iter <= 300:
+        return 25, 5
+    if max_iter <= 1000:
+        return 50, 10
+    return 100, 25
+
+
+def finish_figure(fig, axes: Sequence, output_path: Path | None, show: bool) -> None:
+    major_step, minor_step = iteration_tick_steps(axes)
+    for ax in axes:
+        ax.xaxis.set_major_locator(ticker.MultipleLocator(major_step))
+        ax.xaxis.set_minor_locator(ticker.MultipleLocator(minor_step))
+        ax.tick_params(axis="x", which="both", labelbottom=True)
+        ax.grid(True, which="minor", axis="x", alpha=0.12)
+    plt.tight_layout()
+
+    if output_path:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        fig.savefig(output_path, dpi=150, bbox_inches="tight")
+        print(f"Saved: {output_path}")
+
+    if show:
+        plt.show()
+
+    plt.close(fig)
+
+
+def plot_overview(rows: list[dict], metrics_path: Path, output_path: Path | None, show: bool) -> None:
+    trained = trained_rows(rows)
+    iters = field(rows, "iteration")
+    elapsed = field(rows, "elapsed_hours", 0.0)
+    t_iters = field(trained, "iteration")
+
+    best_iter = rows[-1].get("best_iteration", 0)
+    best_win_rate = rows[-1].get("best_arena_win_rate", 0.0)
+
+    fig, axes = plt.subplots(9, 1, figsize=(10, 23), sharex=True)
+    fig.suptitle(
+        f"{metrics_path.parent.name}  |  iter {int(iters[-1])}  |  best iter {best_iter}  |  "
+        f"best win rate {best_win_rate:.3f}  |  {elapsed[-1]:.2f}h",
+        fontsize=12,
+        fontweight="bold",
+    )
+
+    ax = axes[0]
+    plot_curve(ax, t_iters, field(trained, "train_loss"), color="steelblue", linewidth=1.5, label="total")
+    ax.set_title("Train Loss")
+    ax.set_xlabel("iteration")
+    ax.legend(fontsize=8)
+    ax.grid(True, alpha=0.3)
+
+    ax = axes[1]
+    plot_curve(ax, t_iters, field(trained, "policy_loss"), color="darkorange", linewidth=1.5, label="policy")
+    ax.axhline(UNIFORM_POLICY_ENTROPY_15X15, color="gray", linestyle="--", linewidth=0.8, label="uniform ln(225)")
+    ax.set_title("Policy Loss")
+    ax.set_xlabel("iteration")
+    ax.legend(fontsize=8)
+    ax.grid(True, alpha=0.3)
+
+    ax = axes[2]
+    plot_curve(ax, t_iters, field(trained, "value_loss"), color="seagreen", linewidth=1.5, label="value")
+    ax.set_title("Value Loss")
+    ax.set_xlabel("iteration")
+    ax.legend(fontsize=8)
+    ax.grid(True, alpha=0.3)
+
+    ax = axes[3]
+    plot_curve(ax, t_iters, field(trained, "learning_rate"), color="crimson", linewidth=1.5, label="learning rate")
+    ax.set_title("Learning Rate")
+    ax.set_xlabel("iteration")
+    ax.legend(fontsize=8)
+    ax.grid(True, alpha=0.3)
+
+    ax = axes[4]
+    arena_win_rate = field(trained, "arena_win_rate")
+    accepted_iters = [r["iteration"] for r in trained if r.get("accepted")]
+    plot_curve(ax, t_iters, [v * 100 for v in arena_win_rate], color="mediumpurple", linewidth=1.5, label="win rate")
+    if accepted_iters:
+        accept_wr = [arena_win_rate[t_iters.index(i)] * 100 for i in accepted_iters if i in t_iters]
+        ax.scatter(accepted_iters, accept_wr, color="gold", zorder=5, s=40, label="accepted")
+    accept_threshold = trained[0].get("arena_accept_win_rate") if trained else None
+    if accept_threshold is not None:
+        ax.axhline(accept_threshold * 100, color="gray", linestyle="--", linewidth=0.8, label=f"threshold {accept_threshold:.0%}")
+    ax.set_title("Arena Win Rate")
+    ax.set_xlabel("iteration")
+    ax.set_ylabel("percent")
+    ax.set_ylim(0, 100)
+    ax.yaxis.set_major_formatter(ticker.PercentFormatter(xmax=100))
+    ax.legend(fontsize=8)
+    ax.grid(True, alpha=0.3)
+
+    ax = axes[5]
+    plot_curve(ax, t_iters, [v * 100 for v in field(trained, "arena_candidate_white_win_rate")], color="saddlebrown", linewidth=1.5, label="white win rate")
+    white_threshold = trained[0].get("arena_white_win_rate_threshold") if trained else None
+    if white_threshold is not None:
+        ax.axhline(white_threshold * 100, color="gray", linestyle="--", linewidth=0.8, label=f"threshold {white_threshold:.0%}")
+    ax.set_title("Arena Candidate White Win Rate")
+    ax.set_xlabel("iteration")
+    ax.set_ylabel("percent")
+    ax.set_ylim(0, 100)
+    ax.yaxis.set_major_formatter(ticker.PercentFormatter(xmax=100))
+    ax.legend(fontsize=8)
+    ax.grid(True, alpha=0.3)
+
+    ax = axes[6]
+    plot_curve(ax, iters, field(rows, "selfplay_avg_moves"), color="tomato", linewidth=1.5)
+    ax.set_title("Selfplay Avg Moves")
+    ax.set_xlabel("iteration")
+    ax.grid(True, alpha=0.3)
+
+    ax = axes[7]
+    plot_curve(ax, iters, field(rows, "replay_games", 0.0), color="teal", linewidth=1.5)
+    ax.set_title("Replay Buffer Games")
+    ax.set_xlabel("iteration")
+    ax.yaxis.set_major_formatter(ticker.FuncFormatter(lambda v, _: f"{int(v):,}"))
+    ax.grid(True, alpha=0.3)
+
+    ax = axes[8]
+    plot_curve(ax, iters, elapsed, color="slategray", linewidth=1.5)
+    ax.set_title("Elapsed Hours")
+    ax.set_xlabel("iteration")
+    ax.grid(True, alpha=0.3)
+
+    finish_figure(fig, axes, output_path, show)
+
+
+def plot_timing(rows: list[dict], metrics_path: Path, output_path: Path | None, show: bool) -> None:
+    trained = trained_rows(rows)
+    iters = field(rows, "iteration")
+    t_iters = field(trained, "iteration")
+
+    fig, axes = plt.subplots(5, 1, figsize=(10, 14), sharex=True)
+    fig.suptitle(f"{metrics_path.parent.name} timing", fontsize=12, fontweight="bold")
+
+    ax = axes[0]
+    plot_curve(ax, iters, field(rows, "duration_seconds"), color="black", linewidth=1.5, label="total")
+    plot_curve(ax, iters, field(rows, "selfplay_seconds"), color="dodgerblue", linewidth=1.2, label="selfplay")
+    plot_curve(ax, iters, field(rows, "train_seconds"), color="seagreen", linewidth=1.2, label="train")
+    plot_curve(ax, iters, field(rows, "arena_seconds"), color="mediumpurple", linewidth=1.2, label="arena")
+    ax.set_title("Phase Seconds")
+    ax.set_xlabel("iteration")
+    ax.legend(fontsize=8, ncol=4)
+    ax.grid(True, alpha=0.3)
+
+    ax = axes[1]
+    plot_curve(ax, t_iters, field(trained, "train_sample_seconds"), color="teal", linewidth=1.2, label="sample")
+    plot_curve(ax, t_iters, field(trained, "train_forward_seconds"), color="steelblue", linewidth=1.2, label="forward")
+    plot_curve(ax, t_iters, field(trained, "train_loss_seconds"), color="gray", linewidth=1.2, label="loss")
+    plot_curve(ax, t_iters, field(trained, "train_backward_seconds"), color="tomato", linewidth=1.2, label="backward")
+    plot_curve(ax, t_iters, field(trained, "train_optimizer_seconds"), color="darkorange", linewidth=1.2, label="optimizer")
+    ax.set_title("Training Step Seconds")
+    ax.set_xlabel("iteration")
+    ax.legend(fontsize=8, ncol=5)
+    ax.grid(True, alpha=0.3)
+
+    ax = axes[2]
+    plot_curve(ax, iters, summed_field(rows, "search_selfplay_candidate_seconds", "search_selfplay_best_seconds"), color="dodgerblue", linewidth=1.5, label="selfplay")
+    plot_curve(ax, iters, summed_field(rows, "search_arena_candidate_seconds", "search_arena_best_seconds"), color="mediumpurple", linewidth=1.5, label="arena")
+    ax.set_title("MCTS Search Seconds")
+    ax.set_xlabel("iteration")
+    ax.legend(fontsize=8)
+    ax.grid(True, alpha=0.3)
+
+    ax = axes[3]
+    plot_curve(ax, iters, summed_field(rows, "eval_selfplay_candidate_seconds", "eval_selfplay_best_seconds"), color="dodgerblue", linewidth=1.5, label="selfplay")
+    plot_curve(ax, iters, summed_field(rows, "eval_arena_candidate_seconds", "eval_arena_best_seconds"), color="mediumpurple", linewidth=1.5, label="arena")
+    ax.set_title("Neural Evaluator Seconds")
+    ax.set_xlabel("iteration")
+    ax.legend(fontsize=8)
+    ax.grid(True, alpha=0.3)
+
+    ax = axes[4]
+    plot_curve(ax, iters, field(rows, "checkpoint_seconds"), color="slategray", linewidth=1.5)
+    ax.set_title("Checkpoint Seconds")
+    ax.set_xlabel("iteration")
+    ax.grid(True, alpha=0.3)
+
+    finish_figure(fig, axes, output_path, show)
+
+
+def plot_throughput(rows: list[dict], metrics_path: Path, output_path: Path | None, show: bool) -> None:
+    trained = trained_rows(rows)
+    iters = field(rows, "iteration")
+    t_iters = field(trained, "iteration")
+
+    selfplay_eval_seconds = summed_field(rows, "eval_selfplay_candidate_seconds", "eval_selfplay_best_seconds")
+    arena_eval_seconds = summed_field(rows, "eval_arena_candidate_seconds", "eval_arena_best_seconds")
+    selfplay_eval_positions = summed_field(rows, "eval_selfplay_candidate_positions", "eval_selfplay_best_positions")
+    arena_eval_positions = summed_field(rows, "eval_arena_candidate_positions", "eval_arena_best_positions")
+    selfplay_search_seconds = summed_field(rows, "search_selfplay_candidate_seconds", "search_selfplay_best_seconds")
+    arena_search_seconds = summed_field(rows, "search_arena_candidate_seconds", "search_arena_best_seconds")
+    selfplay_search_states = summed_field(rows, "search_selfplay_candidate_states", "search_selfplay_best_states")
+    arena_search_states = summed_field(rows, "search_arena_candidate_states", "search_arena_best_states")
+
+    fig, axes = plt.subplots(5, 1, figsize=(10, 14), sharex=True)
+    fig.suptitle(f"{metrics_path.parent.name} throughput", fontsize=12, fontweight="bold")
+
+    ax = axes[0]
+    plot_curve(ax, iters, rate(field(rows, "selfplay_games", 0.0), field(rows, "selfplay_seconds")), color="dodgerblue", linewidth=1.5)
+    ax.set_title("Selfplay Games / Second")
+    ax.set_xlabel("iteration")
+    ax.grid(True, alpha=0.3)
+
+    ax = axes[1]
+    plot_curve(ax, t_iters, rate(field(trained, "train_metric_samples", 0.0), field(trained, "train_seconds")), color="seagreen", linewidth=1.5, label="samples/sec")
+    plot_curve(ax, t_iters, rate(field(trained, "updates_done", 0.0), field(trained, "train_seconds")), color="darkorange", linewidth=1.5, label="updates/sec")
+    ax.set_title("Training Throughput")
+    ax.set_xlabel("iteration")
+    ax.legend(fontsize=8)
+    ax.grid(True, alpha=0.3)
+
+    ax = axes[2]
+    plot_curve(ax, iters, rate(selfplay_eval_positions, selfplay_eval_seconds), color="dodgerblue", linewidth=1.5, label="selfplay")
+    plot_curve(ax, iters, rate(arena_eval_positions, arena_eval_seconds), color="mediumpurple", linewidth=1.5, label="arena")
+    ax.set_title("Evaluator Positions / Second")
+    ax.set_xlabel("iteration")
+    ax.legend(fontsize=8)
+    ax.grid(True, alpha=0.3)
+
+    ax = axes[3]
+    plot_curve(ax, iters, rate(selfplay_search_states, selfplay_search_seconds), color="dodgerblue", linewidth=1.5, label="selfplay")
+    plot_curve(ax, iters, rate(arena_search_states, arena_search_seconds), color="mediumpurple", linewidth=1.5, label="arena")
+    ax.set_title("MCTS Search States / Second")
+    ax.set_xlabel("iteration")
+    ax.legend(fontsize=8)
+    ax.grid(True, alpha=0.3)
+
+    ax = axes[4]
+    plot_curve(ax, iters, field(rows, "eval_selfplay_candidate_avg_batch"), color="darkcyan", linewidth=1.5, label="candidate")
+    plot_curve(ax, iters, field(rows, "eval_selfplay_best_avg_batch"), color="slateblue", linewidth=1.5, label="best")
+    ax.set_title("Selfplay Evaluator Avg Batch")
+    ax.set_xlabel("iteration")
+    ax.legend(fontsize=8)
+    ax.grid(True, alpha=0.3)
+
+    finish_figure(fig, axes, output_path, show)
+
+
+def plot(metrics_path: Path, output_path: Path | None, show: bool, *, timing: bool = False, throughput: bool = False) -> None:
+    rows = load_metrics(metrics_path)
+    if not rows:
+        print(f"No data in {metrics_path}")
+        return
+    rows = normalized_iteration_rows(rows)
+
+    plot_overview(metrics_path=metrics_path, rows=rows, output_path=output_path, show=show)
+    if timing:
+        target = None if output_path is None else output_path.with_name(output_path.stem + "_timing" + output_path.suffix)
+        plot_timing(metrics_path=metrics_path, rows=rows, output_path=target, show=show)
+    if throughput:
+        target = None if output_path is None else output_path.with_name(output_path.stem + "_throughput" + output_path.suffix)
+        plot_throughput(metrics_path=metrics_path, rows=rows, output_path=target, show=show)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Plot omok training metrics from metrics.jsonl.")
+    parser.add_argument("metrics", type=str, help="Path to metrics.jsonl or checkpoint directory")
+    parser.add_argument("--output", "-o", type=str, default=None, help="Output PNG path (default: <checkpoint_dir>/metrics.png)")
+    parser.add_argument("--show", action="store_true", help="Open interactive matplotlib window")
+    parser.add_argument("--timing", action="store_true", help="Also write timing breakdown plot")
+    parser.add_argument("--throughput", action="store_true", help="Also write throughput plot")
+    parser.add_argument("--all", action="store_true", help="Write overview, timing, and throughput plots")
+    args = parser.parse_args()
+
+    path = Path(args.metrics)
+    if path.is_dir():
+        metrics_path = path / "metrics.jsonl"
+    else:
+        metrics_path = path
+
+    if not metrics_path.exists():
+        raise FileNotFoundError(metrics_path)
+
+    if args.output:
+        output_path = Path(args.output)
+    else:
+        output_path = metrics_path.parent / "metrics.png"
+
+    write_output = output_path if not args.show or args.output else None
+    plot(
+        metrics_path,
+        write_output,
+        args.show,
+        timing=args.timing or args.all,
+        throughput=args.throughput or args.all,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/coolrl/omok15/replay.py
+++ b/src/coolrl/omok15/replay.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+
+from .features import apply_symmetry_batch, encode_feature_planes_batch
+
+
+@dataclass(slots=True)
+class PendingSample:
+    board: np.ndarray
+    to_play: int
+    last_action: int | None
+    policy: np.ndarray
+
+
+@dataclass(slots=True)
+class ReplaySample:
+    board: np.ndarray
+    to_play: int
+    last_action: int | None
+    policy: np.ndarray
+    value: float
+
+
+class ReplayBuffer:
+    def __init__(self, capacity: int) -> None:
+        self.capacity = int(capacity)
+        self.samples: deque[ReplaySample] = deque(maxlen=self.capacity)
+        self.games_seen = 0
+
+    def __len__(self) -> int:
+        return len(self.samples)
+
+    def add_game(
+        self,
+        history: Iterable[PendingSample],
+        winner: int,
+        value_discount: float = 1.0,
+    ) -> None:
+        history_list = list(history)
+        total = len(history_list)
+        if total == 0:
+            return
+        discount = float(np.clip(value_discount, 0.0, 1.0))
+        for idx, item in enumerate(history_list):
+            if winner == 0:
+                value = 0.0
+            else:
+                outcome = 1.0 if winner == item.to_play else -1.0
+                remaining = total - 1 - idx
+                value = outcome * (discount ** remaining)
+            self.samples.append(
+                ReplaySample(
+                    board=np.asarray(item.board, dtype=np.int8),
+                    to_play=int(item.to_play),
+                    last_action=item.last_action,
+                    policy=np.asarray(item.policy, dtype=np.float32),
+                    value=float(value),
+                )
+            )
+        self.games_seen += 1
+
+    def sample_batch_numpy(
+        self,
+        batch_size: int,
+        device: str | None = None,
+        recency_temperature: float = 0.0,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        if len(self.samples) < batch_size:
+            raise ValueError("not enough replay data to sample a batch")
+        total = len(self.samples)
+        if recency_temperature > 0.0 and total > 1:
+            positions = np.arange(total, dtype=np.float64)
+            log_weights = recency_temperature * (positions - (total - 1))
+            log_weights -= log_weights.max()
+            weights = np.exp(log_weights)
+            weights /= weights.sum()
+            indices = np.random.choice(total, size=batch_size, replace=False, p=weights)
+        else:
+            indices = np.random.choice(total, size=batch_size, replace=False)
+
+        batch = [self.samples[index] for index in indices]
+        boards = np.stack([sample.board for sample in batch], axis=0).astype(np.int8, copy=False)
+        to_play = np.fromiter((sample.to_play for sample in batch), dtype=np.int8, count=batch_size)
+        last_actions = np.fromiter(
+            (-1 if sample.last_action is None else sample.last_action for sample in batch),
+            dtype=np.int32,
+            count=batch_size,
+        )
+        policy_batch = np.stack([sample.policy for sample in batch], axis=0).astype(np.float32, copy=False)
+        value_batch = np.fromiter((sample.value for sample in batch), dtype=np.float32, count=batch_size)
+        planes_batch = encode_feature_planes_batch(boards, to_play, last_actions, boards.shape[-1])
+        planes_batch, policy_batch = apply_symmetry_batch(planes_batch, policy_batch)
+
+        return (
+            np.ascontiguousarray(planes_batch),
+            np.ascontiguousarray(policy_batch),
+            np.ascontiguousarray(value_batch),
+        )
+
+    def sample_batch_torch(
+        self,
+        batch_size: int,
+        device: str | None = None,
+        recency_temperature: float = 0.0,
+    ) -> tuple["torch.Tensor", "torch.Tensor", "torch.Tensor"]:
+        states_np, policy_np, value_np = self.sample_batch_numpy(
+            batch_size,
+            recency_temperature=recency_temperature,
+        )
+
+        import torch
+
+        if device is None:
+            return (
+                torch.as_tensor(states_np),
+                torch.as_tensor(policy_np),
+                torch.as_tensor(value_np),
+            )
+        return (
+            torch.as_tensor(states_np, device=device),
+            torch.as_tensor(policy_np, device=device),
+            torch.as_tensor(value_np, device=device),
+        )
+
+    def sample_batch(
+        self,
+        batch_size: int,
+        device: str | None = None,
+        recency_temperature: float = 0.0,
+    ) -> tuple["torch.Tensor", "torch.Tensor", "torch.Tensor"]:
+        return self.sample_batch_torch(
+            batch_size,
+            device=device,
+            recency_temperature=recency_temperature,
+        )
+
+    def state_dict(self) -> dict[str, object]:
+        return {
+            "capacity": self.capacity,
+            "games_seen": self.games_seen,
+            "samples": [
+                {
+                    "board": sample.board,
+                    "to_play": sample.to_play,
+                    "last_action": sample.last_action,
+                    "policy": sample.policy,
+                    "value": sample.value,
+                }
+                for sample in self.samples
+            ],
+        }
+
+    def load_state_dict(self, state: dict[str, object]) -> None:
+        self.capacity = int(state.get("capacity", self.capacity))
+        self.samples = deque(maxlen=self.capacity)
+        for item in state.get("samples", []):
+            payload = dict(item)
+            self.samples.append(
+                ReplaySample(
+                    board=np.asarray(payload["board"], dtype=np.int8),
+                    to_play=int(payload["to_play"]),
+                    last_action=payload["last_action"],
+                    policy=np.asarray(payload["policy"], dtype=np.float32),
+                    value=float(payload["value"]),
+                )
+            )
+        self.games_seen = int(state.get("games_seen", 0))

--- a/src/coolrl/omok15/selfplay_worker.py
+++ b/src/coolrl/omok15/selfplay_worker.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import os
+import random
+from typing import Any
+
+import numpy as np
+
+
+def _selfplay_temperature(move_count: int, temperature_moves: int, temperature_end: float) -> float:
+    if temperature_moves <= 0:
+        return float(temperature_end)
+    if move_count >= temperature_moves:
+        return float(temperature_end)
+    frac = move_count / float(temperature_moves)
+    return 1.0 + (float(temperature_end) - 1.0) * frac
+
+
+_WORKER_STATE: dict[str, Any] = {}
+
+
+def worker_init(config_payload: dict, state_numpy: dict[str, np.ndarray]) -> None:
+    os.environ.setdefault("PYGAME_HIDE_SUPPORT_PROMPT", "1")
+
+    import torch
+
+    from .config import config_from_dict
+    from .mcts_backend import resolve_mcts_backend
+    from .torch_evaluator import build_evaluator
+    from .torch_network import PolicyValueNet
+
+    config = config_from_dict(config_payload)
+    mcts_module = resolve_mcts_backend(config.selfplay.mcts_backend)
+    backend = config.selfplay.evaluator_backend.lower()
+    if backend == "auto":
+        backend = "torch"
+    if backend != "torch":
+        raise RuntimeError("unsupported evaluator backend; use 'torch'")
+
+    model = PolicyValueNet(config.rules.board_size, config.network)
+    model.load_state_dict({key: torch.as_tensor(np.asarray(value)) for key, value in state_numpy.items()})
+    model.to("cpu")
+    model.eval()
+
+    evaluator = build_evaluator(model, backend=backend, device="CPU")
+    search = mcts_module.MCTS(
+        c_puct=config.selfplay.c_puct,
+        dirichlet_alpha=config.selfplay.dirichlet_alpha,
+        dirichlet_epsilon=config.selfplay.dirichlet_epsilon,
+        evaluator=evaluator,
+        search_threads=config.selfplay.search_threads,
+        virtual_loss=config.selfplay.virtual_loss,
+    )
+
+    _WORKER_STATE.clear()
+    _WORKER_STATE["config"] = config
+    _WORKER_STATE["model"] = model
+    _WORKER_STATE["evaluator"] = evaluator
+    _WORKER_STATE["search"] = search
+    _WORKER_STATE["torch"] = torch
+
+
+
+def run_selfplay_chunk(
+    openings: list[list[int]],
+    simulations: int,
+    seed: int,
+    chunk_id: int,
+    progress_queue: Any | None = None,
+) -> list[tuple[list[dict], int]]:
+    from .board import GameState
+    from .replay import PendingSample
+
+    config = _WORKER_STATE["config"]
+    search = _WORKER_STATE["search"]
+    torch = _WORKER_STATE.get("torch")
+    random.seed(seed)
+    np.random.seed(seed & 0xFFFFFFFF)
+    if torch is not None:
+        torch.manual_seed(seed)
+
+    if progress_queue is not None:
+        progress_queue.put(
+            {
+                "type": "chunk_started",
+                "chunk_id": chunk_id,
+                "chunk_size": len(openings),
+                "pid": os.getpid(),
+            }
+        )
+
+    finished: list[tuple[list[dict], int]] = []
+    states: list[GameState] = []
+    histories: list[list[PendingSample]] = []
+    roots = []
+    completed_in_chunk = 0
+
+    for opening in openings:
+        state = GameState(config.rules.board_size, config.rules.exactly_five)
+        for action in opening:
+            if state.terminal:
+                break
+            if state.legal_moves()[action]:
+                state.apply_action(action)
+        if state.terminal:
+            finished.append(([], state.winner))
+            completed_in_chunk += 1
+            if progress_queue is not None:
+                progress_queue.put(
+                    {
+                        "type": "game_done",
+                        "chunk_id": chunk_id,
+                        "chunk_size": len(openings),
+                        "chunk_done": completed_in_chunk,
+                        "pid": os.getpid(),
+                        "moves": 0,
+                        "winner": state.winner,
+                    }
+                )
+            continue
+        states.append(state)
+        histories.append([])
+        roots.append(None)
+
+    while states:
+        if progress_queue is not None:
+            progress_queue.put(
+                {
+                    "type": "game_moves",
+                    "chunk_id": chunk_id,
+                    "pid": os.getpid(),
+                    "moves": len(states),
+                    "active_games": len(states),
+                }
+            )
+        temperatures = [
+            _selfplay_temperature(
+                state.move_count,
+                config.selfplay.temperature_moves,
+                config.selfplay.temperature_end,
+            )
+            for state in states
+        ]
+        results = search.search_batch(
+            states,
+            simulations,
+            temperatures,
+            add_noise=True,
+            roots=roots,
+            leaves_per_batch=config.selfplay.leaves_per_batch,
+        )
+        next_states: list[GameState] = []
+        next_histories: list[list[PendingSample]] = []
+        next_roots = []
+        for state, history, result in zip(states, histories, results, strict=True):
+            history.append(
+                PendingSample(
+                    board=state.board.copy(),
+                    to_play=state.to_play,
+                    last_action=state.last_action,
+                    policy=result.visit_policy.copy(),
+                )
+            )
+            state.apply_action(result.action)
+            if state.terminal:
+                finished.append(
+                    (
+                        [
+                            {
+                                "board": sample.board,
+                                "to_play": sample.to_play,
+                                "last_action": sample.last_action,
+                                "policy": sample.policy,
+                            }
+                            for sample in history
+                        ],
+                        state.winner,
+                    )
+                )
+                completed_in_chunk += 1
+                if progress_queue is not None:
+                    progress_queue.put(
+                        {
+                            "type": "game_done",
+                            "chunk_id": chunk_id,
+                            "chunk_size": len(openings),
+                            "chunk_done": completed_in_chunk,
+                            "pid": os.getpid(),
+                            "moves": len(history),
+                            "winner": state.winner,
+                        }
+                    )
+            else:
+                next_states.append(state)
+                next_histories.append(history)
+                next_roots.append(result.next_root)
+        states = next_states
+        histories = next_histories
+        roots = next_roots
+
+    return finished
+
+
+def model_state_to_numpy(model) -> dict[str, np.ndarray]:
+    state = model.state_dict()
+    output: dict[str, np.ndarray] = {}
+    for key, value in state.items():
+        if hasattr(value, "realize"):
+            output[key] = np.array(value.realize().numpy(), copy=True)
+        elif hasattr(value, "detach"):
+            output[key] = np.array(value.detach().cpu().numpy(), copy=True)
+        else:
+            output[key] = np.array(value, copy=True)
+    return output

--- a/src/coolrl/omok15/torch_evaluator.py
+++ b/src/coolrl/omok15/torch_evaluator.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import numpy as np
+from loguru import logger
+
+from .board import GameState
+from .evaluator import Evaluator
+from .features import states_to_feature_planes
+from .torch_network import PolicyValueNet as TorchPolicyValueNet
+
+try:
+    import torch
+    import torch.nn as torch_nn
+except ModuleNotFoundError:  # pragma: no cover - exercised only without torch installed.
+    torch = None
+    torch_nn = None
+
+
+def _require_torch() -> None:
+    if torch is None:
+        raise RuntimeError(
+            "PyTorch is required for Omok evaluation. "
+            "Install torch or run with `uv run --extra omok ...`."
+        )
+
+
+def _torch_device(requested_device: str | None) -> "torch.device":
+    _require_torch()
+    name = (requested_device or "auto").upper()
+    if name == "CUDA":
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA requested for torch evaluator, but torch.cuda is unavailable")
+        return torch.device("cuda")
+    if name in {"METAL", "GPU"}:
+        if torch.backends.mps.is_available():
+            return torch.device("mps")
+        raise RuntimeError("Metal/MPS requested for torch evaluator, but torch.backends.mps is unavailable")
+    if name == "CPU":
+        return torch.device("cpu")
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    if torch.backends.mps.is_available():
+        return torch.device("mps")
+    return torch.device("cpu")
+
+
+def _coerce_torch_model(model: object) -> TorchPolicyValueNet:
+    _require_torch()
+    if isinstance(model, TorchPolicyValueNet):
+        return model
+    if isinstance(model, torch_nn.Module):
+        return model  # type: ignore[return-value]
+    raise TypeError("torch evaluator expects a PyTorch nn.Module")
+
+
+class TorchModelEvaluator(Evaluator):
+    def __init__(self, model: object, device: str | None = None) -> None:
+        _require_torch()
+        self.device = _torch_device(device)
+        self.model = _coerce_torch_model(model)
+        self.model.to(self.device)
+        self.model.eval()
+        if self.device.type == "cuda":
+            torch.backends.cudnn.benchmark = True
+            torch.backends.cuda.matmul.allow_tf32 = True
+            torch.backends.cudnn.allow_tf32 = True
+        logger.info("Torch evaluator initialized: device={}", self.device)
+
+    def effective_batch_size(self, batch_size: int) -> int:
+        return batch_size
+
+    def evaluate(self, states: list[GameState]) -> tuple[np.ndarray, np.ndarray]:
+        features = states_to_feature_planes(states)
+        return self.evaluate_features(features)
+
+    def evaluate_features(self, features: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        array = np.ascontiguousarray(features)
+        with torch.inference_mode():
+            tensor = torch.as_tensor(array, device=self.device)
+            logits, values = self.model(tensor)
+            priors = torch.softmax(logits, dim=1).detach().cpu().numpy()
+            value_np = values.detach().cpu().numpy()
+
+        return priors.astype(np.float32, copy=False), value_np.astype(np.float32, copy=False)
+
+
+def build_evaluator(model: object, *, backend: str, device: str | None) -> Evaluator:
+    token = backend.strip().lower()
+    if token in {"torch", "auto"}:
+        return TorchModelEvaluator(model, device=device)
+    raise ValueError(f"unsupported selfplay.evaluator_backend: {backend!r}; use 'torch'")

--- a/src/coolrl/omok15/torch_network.py
+++ b/src/coolrl/omok15/torch_network.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import copy
+from typing import Any, Mapping
+
+import numpy as np
+import torch
+import torch.nn as torch_nn
+import torch.nn.functional as torch_f
+
+from .config import NetworkConfig
+
+
+def _as_numpy(value: Any) -> np.ndarray:
+    if hasattr(value, "realize"):
+        value = value.realize().numpy()
+    return np.array(value)
+
+
+class TorchSEBlock(torch_nn.Module):
+    def __init__(self, channels: int, reduction: int) -> None:
+        super().__init__()
+        hidden = max(8, channels // max(1, reduction))
+        self.fc1 = torch_nn.Linear(channels, hidden)
+        self.fc2 = torch_nn.Linear(hidden, channels)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        batch, channels, _, _ = x.shape
+        pooled = x.mean(dim=(2, 3))
+        weights = torch.sigmoid(self.fc2(self.fc1(torch_f.relu(pooled))))
+        return x * weights.reshape(batch, channels, 1, 1)
+
+
+class TorchResidualBlock(torch_nn.Module):
+    def __init__(self, channels: int, se_reduction: int) -> None:
+        super().__init__()
+        self.conv1 = torch_nn.Conv2d(channels, channels, kernel_size=3, padding=1, bias=False)
+        self.bn1 = torch_nn.BatchNorm2d(channels)
+        self.conv2 = torch_nn.Conv2d(channels, channels, kernel_size=3, padding=1, bias=False)
+        self.bn2 = torch_nn.BatchNorm2d(channels)
+        self.se = TorchSEBlock(channels, se_reduction)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        residual = x
+        x = torch_f.relu(self.bn1(self.conv1(x)))
+        x = self.bn2(self.conv2(x))
+        x = self.se(x)
+        return torch_f.relu(x + residual)
+
+
+class PolicyValueNet(torch_nn.Module):
+    def __init__(self, board_size: int, cfg: NetworkConfig) -> None:
+        super().__init__()
+        if board_size != 15:
+            raise ValueError("PolicyValueNet is fixed to 15x15")
+        action_size = board_size * board_size
+        channels = cfg.channels
+
+        self.stem_conv = torch_nn.Conv2d(cfg.input_planes, channels, kernel_size=3, padding=1, bias=False)
+        self.stem_bn = torch_nn.BatchNorm2d(channels)
+        self.tower = torch_nn.ModuleList(
+            [TorchResidualBlock(channels, cfg.se_reduction) for _ in range(cfg.blocks)]
+        )
+
+        self.policy_conv = torch_nn.Conv2d(channels, 2, kernel_size=1, bias=False)
+        self.policy_bn = torch_nn.BatchNorm2d(2)
+        self.policy_fc = torch_nn.Linear(2 * action_size, action_size)
+
+        self.value_conv = torch_nn.Conv2d(channels, 1, kernel_size=1, bias=False)
+        self.value_bn = torch_nn.BatchNorm2d(1)
+        self.value_fc1 = torch_nn.Linear(action_size, cfg.value_hidden)
+        self.value_fc2 = torch_nn.Linear(cfg.value_hidden, 1)
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        x = torch_f.relu(self.stem_bn(self.stem_conv(x)))
+        for block in self.tower:
+            x = block(x)
+
+        policy = torch_f.relu(self.policy_bn(self.policy_conv(x)))
+        policy_logits = self.policy_fc(policy.reshape(policy.shape[0], -1))
+
+        value = torch_f.relu(self.value_bn(self.value_conv(x)))
+        value = torch_f.tanh(self.value_fc2(torch_f.relu(self.value_fc1(value.reshape(value.shape[0], -1)))))
+        return policy_logits, value.reshape(value.shape[0])
+
+
+# Backward compatibility alias used in plan wording and some runtime code paths.
+TorchPolicyValueNet = PolicyValueNet
+
+
+def load_legacy_state_dict(model: PolicyValueNet, legacy_state: Mapping[str, Any]) -> None:
+    target_state = model.state_dict()
+    source_state = {key: _as_numpy(value) for key, value in legacy_state.items()}
+    missing = sorted(set(target_state) - set(source_state))
+    extra = sorted(set(source_state) - set(target_state))
+    if missing or extra:
+        raise RuntimeError(f"legacy/torch state mismatch: missing={missing} extra={extra}")
+
+    converted: dict[str, torch.Tensor] = {}
+    for key, target_tensor in target_state.items():
+        source = source_state[key]
+        dtype = target_tensor.dtype
+        if dtype == torch.long:
+            converted[key] = torch.as_tensor(source, dtype=dtype)
+        else:
+            converted[key] = torch.as_tensor(source, dtype=dtype)
+    model.load_state_dict(converted, strict=True)
+
+
+def clone_model(model: PolicyValueNet) -> PolicyValueNet:
+    return copy.deepcopy(model)

--- a/src/coolrl/omok15/train.py
+++ b/src/coolrl/omok15/train.py
@@ -1,0 +1,1129 @@
+from __future__ import annotations
+
+import argparse
+import json
+import multiprocessing as mp
+import os
+import random
+import signal
+import shutil
+import time
+from concurrent.futures import FIRST_COMPLETED, Future, ProcessPoolExecutor, wait
+from pathlib import Path
+from queue import Empty
+from typing import Any
+
+import numpy as np
+import torch
+from loguru import logger
+from rich.progress import Progress, TaskID
+
+from coolrl.progress import RichLogSink, make_progress
+
+from .arena import Arena
+from .board import GameState
+from .checkpoint import (
+    load_checkpoint,
+    load_trainer_state,
+    save_checkpoint,
+    save_trainer_state,
+)
+from .config import RunConfig, load_config
+from .evaluator import Evaluator
+from .mcts_backend import resolve_mcts_backend
+from .metrics import IterationMetrics
+from .openings import sample_balanced_openings
+from .replay import PendingSample, ReplayBuffer
+from .selfplay_worker import model_state_to_numpy, run_selfplay_chunk, worker_init
+from .torch_evaluator import build_evaluator
+from .torch_network import PolicyValueNet, clone_model
+
+
+def _preferred_device_name(name: str | None) -> str:
+    requested = (name or "auto").upper()
+    if requested == "CUDA":
+        return "CUDA"
+    if requested in {"CPU", "METAL", "GPU"}:
+        return requested
+    if torch.cuda.is_available():
+        return "CUDA"
+    return "CPU"
+
+
+def _torch_device(name: str | None) -> torch.device:
+    requested = (name or "auto").upper()
+    if requested == "CUDA":
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA requested for training but torch.cuda is unavailable")
+        return torch.device("cuda")
+    if requested in {"METAL", "GPU"}:
+        if torch.backends.mps.is_available():
+            return torch.device("mps")
+        return torch.device("cpu")
+    if requested == "CPU":
+        return torch.device("cpu")
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    return torch.device("cpu")
+
+
+def configure_logging() -> None:
+    logger.remove()
+    logger.add(
+        RichLogSink(),
+        level="INFO",
+        colorize=True,
+        format="<green>{time:HH:mm:ss}</green> | <level>{level:<8}</level> | {message}",
+    )
+
+
+def set_seed(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+class Trainer:
+    def __init__(self, config: RunConfig, resume_path: str | None = None) -> None:
+        self.config = config
+        self.device = _preferred_device_name(config.device)
+        self.torch_device = _torch_device(config.device)
+        self.checkpoint_dir = config.checkpoint_dir
+        self.checkpoint_dir.mkdir(parents=True, exist_ok=True)
+        self.log_file = self.checkpoint_dir / "metrics.jsonl"
+        self.progress_file = self.checkpoint_dir / "runtime_progress.json"
+        if resume_path is None:
+            self._archive_previous_metrics()
+        self.replay = ReplayBuffer(config.optimization.replay_capacity)
+        self.mcts_module = resolve_mcts_backend(config.selfplay.mcts_backend)
+        self.model = PolicyValueNet(config.rules.board_size, config.network).to(self.torch_device)
+        self.best_model = clone_model(self.model)
+        self.model_evaluator: Evaluator | None = None
+        self.best_model_evaluator: Evaluator | None = None
+        self.iteration_metrics: IterationMetrics | None = None
+        self.optimizer = self._build_optimizer()
+        self.selfplay_rng = random.Random(config.seed + 1_048_583)
+        self.iteration = 0
+        self.total_updates = 0
+        self.best_iteration = 0
+        self.best_arena_win_rate = 0.0
+        self.best_checkpoint_metadata: dict[str, Any] = {
+            "iteration": 0,
+            "best_iteration": 0,
+            "best_arena_win_rate": 0.0,
+            "total_updates": 0,
+            "status": "initial_best",
+        }
+        self.start_time = time.monotonic()
+        self.elapsed_seconds_offset = 0.0
+        self.stop_requested = False
+        self.num_workers, num_workers_auto = config.selfplay.resolved_num_workers()
+        if num_workers_auto:
+            logger.info(
+                "Self-play num_workers=auto resolved to {} (os.cpu_count={})",
+                self.num_workers,
+                os.cpu_count(),
+            )
+        else:
+            logger.info("Self-play num_workers={}", self.num_workers)
+        self.search_threads, search_threads_auto = config.selfplay.resolved_search_threads()
+        self.config.selfplay.search_threads = self.search_threads
+        if search_threads_auto:
+            logger.info(
+                "Self-play search_threads=auto resolved to {} (os.cpu_count={})",
+                self.search_threads,
+                os.cpu_count(),
+            )
+        else:
+            logger.info("Self-play search_threads={}", self.search_threads)
+        logger.info("Self-play evaluator_backend={}", self.config.selfplay.evaluator_backend)
+        signal.signal(signal.SIGINT, self._handle_stop_signal)
+        signal.signal(signal.SIGTERM, self._handle_stop_signal)
+        if resume_path:
+            self._restore_from_checkpoint(resume_path)
+        self._refresh_model_evaluators()
+
+    def _archive_previous_metrics(self) -> None:
+        if not self.log_file.exists():
+            return
+        timestamp = time.strftime("%Y%m%d-%H%M%S")
+        archive_path = self.log_file.with_name(f"metrics.{timestamp}.jsonl")
+        shutil.move(self.log_file, archive_path)
+        logger.warning(
+            "Starting fresh run with existing metrics log; archived previous metrics to {}",
+            archive_path,
+        )
+
+    def _build_optimizer(self) -> torch.optim.AdamW:
+        return torch.optim.AdamW(
+            self.model.parameters(),
+            lr=self.config.optimization.learning_rate,
+            betas=(0.9, 0.999),
+            eps=1.0e-8,
+            weight_decay=self.config.optimization.weight_decay,
+        )
+
+    def _refresh_model_evaluators(self) -> None:
+        self.model_evaluator = self._build_evaluator(self.model)
+        self.best_model_evaluator = self._build_evaluator(self.best_model)
+
+    def _build_evaluator(self, model: object) -> Evaluator:
+        return build_evaluator(model, backend=self.config.selfplay.evaluator_backend, device=self.device)
+
+    def _evaluator_for_model(self, model: object) -> Evaluator:
+        if model is self.model:
+            if self.model_evaluator is None:
+                self.model_evaluator = self._build_evaluator(self.model)
+            return self.model_evaluator
+        if model is self.best_model:
+            if self.best_model_evaluator is None:
+                self.best_model_evaluator = self._build_evaluator(self.best_model)
+            return self.best_model_evaluator
+        return self._build_evaluator(model)
+
+    @property
+    def elapsed_hours(self) -> float:
+        return (self.elapsed_seconds_offset + time.monotonic() - self.start_time) / 3600.0
+
+    def run(self) -> None:
+        logger.info(
+            "Starting 15x15 Omok RL: experiment={} device={} checkpoint_dir={}",
+            self.config.experiment_name,
+            self.device,
+            self.checkpoint_dir,
+        )
+        self.save_model_checkpoints({"iteration": self.iteration, "status": "startup"})
+        self.save_runtime_state({"iteration": self.iteration, "status": "startup"})
+
+        while self._should_start_iteration():
+            self.iteration += 1
+            self.iteration_metrics = IterationMetrics()
+            iteration_started = time.monotonic()
+            simulations = self.current_simulations()
+            logger.info("Iteration {} started: simulations={}", self.iteration, simulations)
+
+            selfplay_started = time.monotonic()
+            selfplay_stats = self.generate_selfplay(simulations)
+            selfplay_seconds = time.monotonic() - selfplay_started
+            if self._should_stop():
+                self.save_runtime_state({"iteration": self.iteration, "status": "stopped_after_selfplay"})
+                break
+
+            training_stats: dict[str, float | int] = {}
+            arena_stats: dict[str, float | int | bool | str] = {}
+            train_seconds = 0.0
+            arena_seconds = 0.0
+            if self.replay.games_seen < self.config.optimization.warmup_games:
+                logger.info(
+                    "Warmup: replay_games={} warmup_games={}",
+                    self.replay.games_seen,
+                    self.config.optimization.warmup_games,
+                )
+                status = "warmup"
+            else:
+                train_started = time.monotonic()
+                training_stats = self.train_model()
+                self.model_evaluator = self._build_evaluator(self.model)
+                train_seconds = time.monotonic() - train_started
+                arena_started = time.monotonic()
+                arena_stats = self.evaluate_candidate(simulations)
+                arena_seconds = time.monotonic() - arena_started
+                if bool(arena_stats.get("accepted", False)):
+                    self.best_model = clone_model(self.model)
+                    self.best_model_evaluator = self._build_evaluator(self.best_model)
+                    self.best_iteration = self.iteration
+                    self.best_arena_win_rate = float(arena_stats.get("arena_win_rate", 0.0))
+                    self.best_checkpoint_metadata = {
+                        "iteration": self.iteration,
+                        "best_iteration": self.best_iteration,
+                        "best_arena_win_rate": self.best_arena_win_rate,
+                        "total_updates": self.total_updates,
+                        "status": "accepted",
+                    }
+                    logger.success(
+                        "Promoted new best: iteration={} arena_win_rate={:.3f}",
+                        self.best_iteration,
+                        self.best_arena_win_rate,
+                    )
+                status = "trained"
+
+            metadata = {
+                "iteration": self.iteration,
+                "elapsed_hours": round(self.elapsed_hours, 4),
+                "status": status,
+                "simulations": simulations,
+                "evaluator_backend": self.config.selfplay.evaluator_backend,
+                "best_iteration": self.best_iteration,
+                "best_arena_win_rate": round(self.best_arena_win_rate, 4),
+                "total_updates": self.total_updates,
+                "duration_seconds": round(time.monotonic() - iteration_started, 3),
+                "selfplay_seconds": round(selfplay_seconds, 3),
+                "train_seconds": round(train_seconds, 3),
+                "arena_seconds": round(arena_seconds, 3),
+                **self.iteration_metrics.to_log_fields(),
+                **selfplay_stats,
+                **training_stats,
+                **arena_stats,
+            }
+            checkpoint_started = time.monotonic()
+            self.save_model_checkpoints(metadata)
+            checkpoint_seconds = time.monotonic() - checkpoint_started
+            metadata["checkpoint_seconds"] = round(checkpoint_seconds, 3)
+            metadata["duration_seconds"] = round(time.monotonic() - iteration_started, 3)
+            self._log_iteration_metrics(metadata)
+            self._log(metadata)
+            self.save_runtime_state(metadata)
+
+        logger.success(
+            "Training stopped: iteration={} elapsed_hours={:.4f} best_iteration={}",
+            self.iteration,
+            self.elapsed_hours,
+            self.best_iteration,
+        )
+        self.iteration_metrics = None
+
+    def current_simulations(self) -> int:
+        schedule = self.config.selfplay.simulation_schedule
+        if not schedule:
+            raise ValueError("simulation_schedule must not be empty")
+        if self.config.max_iterations:
+            fraction = min(1.0, max(0, self.iteration - 1) / max(1, self.config.max_iterations))
+        elif self.config.max_hours:
+            fraction = min(1.0, self.elapsed_hours / max(self.config.max_hours, 1.0e-6))
+        elif self.config.selfplay.simulation_ramp_iterations:
+            ramp = max(1, self.config.selfplay.simulation_ramp_iterations)
+            fraction = min(1.0, max(0, self.iteration - 1) / ramp)
+        else:
+            return int(schedule[-1]["simulations"])
+
+        simulations = int(schedule[0]["simulations"])
+        for point in schedule:
+            if fraction >= float(point["fraction"]):
+                simulations = int(point["simulations"])
+        return simulations
+
+    def current_selfplay_plan(self) -> dict[str, int | str]:
+        total_games = self.config.selfplay.games_per_iteration
+        if self.best_iteration == 0:
+            return {"label": "candidate", "candidate_games": total_games}
+
+        mix_iterations = max(0, self.config.selfplay.mixed_iterations_after_promotion)
+        mix_fraction = max(0.0, min(1.0, self.config.selfplay.candidate_mix_fraction))
+        if mix_iterations > 0 and self.iteration <= self.best_iteration + mix_iterations and mix_fraction > 0.0:
+            candidate_games = int(round(total_games * mix_fraction))
+            candidate_games = min(total_games, max(0, candidate_games))
+            if candidate_games == total_games:
+                return {"label": "candidate", "candidate_games": candidate_games}
+            if candidate_games > 0:
+                return {"label": "mixed", "candidate_games": candidate_games}
+        return {"label": "best", "candidate_games": 0}
+
+    def generate_selfplay(self, simulations: int) -> dict[str, float | int]:
+        selfplay_plan = self.current_selfplay_plan()
+        source_label = str(selfplay_plan["label"])
+        candidate_games = int(selfplay_plan["candidate_games"])
+        total_games = self.config.selfplay.games_per_iteration
+        openings = sample_balanced_openings(
+            self.config.rules.board_size,
+            total_games,
+            self.selfplay_rng,
+        )
+        source_openings = {
+            "candidate": openings[:candidate_games],
+            "best": openings[candidate_games:],
+        }
+        black_wins = 0
+        white_wins = 0
+        draws = 0
+        total_moves = 0
+        candidate_completed = 0
+        best_completed = 0
+
+        with make_progress() as progress:
+            progress_task = progress.add_task("Self-play", total=len(openings), status="")
+            for source, source_model in (("candidate", self.model), ("best", self.best_model)):
+                if not source_openings[source] or self._should_stop():
+                    continue
+                stats = self._run_selfplay_source(
+                    source=source,
+                    model=source_model,
+                    openings=source_openings[source],
+                    simulations=simulations,
+                    progress=progress,
+                    progress_task=progress_task,
+                )
+                black_wins += int(stats["black_wins"])
+                white_wins += int(stats["white_wins"])
+                draws += int(stats["draws"])
+                total_moves += int(stats["total_moves"])
+                if source == "candidate":
+                    candidate_completed += int(stats["games"])
+                else:
+                    best_completed += int(stats["games"])
+
+        games = black_wins + white_wins + draws
+        avg_moves = 0.0 if games == 0 else total_moves / games
+        logger.info(
+            "Self-play finished: source={} games={} black={} white={} draws={} avg_moves={:.2f}",
+            source_label,
+            games,
+            black_wins,
+            white_wins,
+            draws,
+            avg_moves,
+        )
+        return {
+            "selfplay_source": source_label,
+            "selfplay_games": games,
+            "selfplay_black_wins": black_wins,
+            "selfplay_white_wins": white_wins,
+            "selfplay_draws": draws,
+            "selfplay_avg_moves": round(avg_moves, 2),
+            "selfplay_candidate_games": candidate_completed,
+            "selfplay_best_games": best_completed,
+            "selfplay_batch_size": max(1, self.config.selfplay.batch_size),
+            "replay_samples": len(self.replay),
+            "replay_games": self.replay.games_seen,
+        }
+
+    def _run_selfplay_source(
+        self,
+        source: str,
+        model: object,
+        openings: list[list[int]],
+        simulations: int,
+        progress: Progress,
+        progress_task: TaskID,
+    ) -> dict[str, int]:
+        num_workers = self.num_workers
+        if num_workers > 0:
+            return self._run_selfplay_source_parallel(
+                source=source,
+                model=model,
+                openings=openings,
+                simulations=simulations,
+                progress=progress,
+                progress_task=progress_task,
+                num_workers=num_workers,
+            )
+        return self._run_selfplay_source_sequential(
+            source=source,
+            model=model,
+            openings=openings,
+            simulations=simulations,
+            progress=progress,
+            progress_task=progress_task,
+        )
+
+    def _run_selfplay_source_sequential(
+        self,
+        source: str,
+        model: object,
+        openings: list[list[int]],
+        simulations: int,
+        progress: Progress,
+        progress_task: TaskID,
+    ) -> dict[str, int]:
+        evaluator = self._evaluator_for_model(model)
+        if self.iteration_metrics is not None:
+            evaluator = self.iteration_metrics.timed_evaluator(f"selfplay_{source}", evaluator)
+        MCTS = self.mcts_module.MCTS
+        batch_size = max(1, self.config.selfplay.batch_size)
+        black_wins = 0
+        white_wins = 0
+        draws = 0
+        total_moves = 0
+        completed_games = 0
+
+        pending_openings = list(openings)
+        while pending_openings and not self._should_stop():
+            batch_openings = pending_openings[:batch_size]
+            del pending_openings[:batch_size]
+            search = MCTS(
+                c_puct=self.config.selfplay.c_puct,
+                dirichlet_alpha=self.config.selfplay.dirichlet_alpha,
+                dirichlet_epsilon=self.config.selfplay.dirichlet_epsilon,
+                evaluator=evaluator,
+                search_threads=self.config.selfplay.search_threads,
+                virtual_loss=self.config.selfplay.virtual_loss,
+            )
+            states: list[GameState] = []
+            histories: list[list[PendingSample]] = []
+            roots = []
+
+            for opening in batch_openings:
+                state = GameState(self.config.rules.board_size, self.config.rules.exactly_five)
+                for action in opening:
+                    if state.terminal:
+                        break
+                    if state.legal_moves()[action]:
+                        state.apply_action(action)
+                if state.terminal:
+                    self.replay.add_game([], state.winner, self.config.optimization.value_discount)
+                    black_wins += int(state.winner == 1)
+                    white_wins += int(state.winner == -1)
+                    draws += int(state.winner == 0)
+                    completed_games += 1
+                    progress.update(progress_task, advance=1, status=f"{source} games")
+                    continue
+                states.append(state)
+                histories.append([])
+                roots.append(None)
+
+            while states and not self._should_stop():
+                temperatures = [self._selfplay_temperature(state.move_count) for state in states]
+                leaves_per_batch = self.config.selfplay.leaves_per_batch
+
+                def run_search() -> list[Any]:
+                    return search.search_batch(
+                        states,
+                        simulations,
+                        temperatures,
+                        add_noise=True,
+                        roots=roots,
+                        leaves_per_batch=leaves_per_batch,
+                    )
+
+                if self.iteration_metrics is None:
+                    results = run_search()
+                else:
+                    results = self.iteration_metrics.time_search(
+                        f"selfplay_{source}",
+                        len(states),
+                        simulations,
+                        leaves_per_batch,
+                        run_search,
+                    )
+
+                next_states: list[GameState] = []
+                next_histories: list[list[PendingSample]] = []
+                next_roots = []
+                for state, history, result in zip(states, histories, results, strict=True):
+                    history.append(
+                        PendingSample(
+                            board=state.board.copy(),
+                            to_play=state.to_play,
+                            last_action=state.last_action,
+                            policy=result.visit_policy.copy(),
+                        )
+                    )
+                    state.apply_action(result.action)
+                    if state.terminal:
+                        self.replay.add_game(history, state.winner, self.config.optimization.value_discount)
+                        total_moves += len(history)
+                        black_wins += int(state.winner == 1)
+                        white_wins += int(state.winner == -1)
+                        draws += int(state.winner == 0)
+                        completed_games += 1
+                        progress.update(progress_task, advance=1, status=f"{source} games")
+                    else:
+                        next_states.append(state)
+                        next_histories.append(history)
+                        next_roots.append(result.next_root)
+                states = next_states
+                histories = next_histories
+                roots = next_roots
+
+        logger.debug(
+            "Self-play source finished: source={} games={} batch_size={}",
+            source,
+            completed_games,
+            batch_size,
+        )
+        return {
+            "games": completed_games,
+            "black_wins": black_wins,
+            "white_wins": white_wins,
+            "draws": draws,
+            "total_moves": total_moves,
+        }
+
+    def _run_selfplay_source_parallel(
+        self,
+        source: str,
+        model: object,
+        openings: list[list[int]],
+        simulations: int,
+        progress: Progress,
+        progress_task: TaskID,
+        num_workers: int,
+    ) -> dict[str, int]:
+        batch_size = max(1, self.config.selfplay.batch_size)
+        chunks = [openings[i : i + batch_size] for i in range(0, len(openings), batch_size)]
+        if not chunks:
+            return {"games": 0, "black_wins": 0, "white_wins": 0, "draws": 0, "total_moves": 0}
+
+        state_numpy = model_state_to_numpy(model)
+        config_payload = self.config.to_dict()
+        seed_base = (self.config.seed * 1_000_003) ^ (self.iteration * 2_654_435_761) ^ hash(source)
+
+        black_wins = 0
+        white_wins = 0
+        draws = 0
+        total_moves = 0
+        completed_games = 0
+
+        self._selfplay_total_moves = 0
+        self._selfplay_completed_games = 0
+        self._selfplay_chunk_moves = {}
+
+        ctx = mp.get_context("spawn")
+        effective_workers = max(1, min(num_workers, len(chunks)))
+        logger.info(
+            "Self-play parallel: source={} workers={} chunks={} batch_size={}",
+            source,
+            effective_workers,
+            len(chunks),
+            batch_size,
+        )
+        with ctx.Manager() as manager:
+            progress_queue = manager.Queue()
+            progress_events_seen = 0
+            chunk_tasks = {
+                idx: progress.add_task(
+                    f"{source} chunk {idx:02d}",
+                    total=len(chunk),
+                    status="pending",
+                )
+                for idx, chunk in enumerate(chunks)
+            }
+            with ProcessPoolExecutor(
+                max_workers=effective_workers,
+                mp_context=ctx,
+                initializer=worker_init,
+                initargs=(config_payload, state_numpy),
+            ) as pool:
+                futures = {
+                    pool.submit(
+                        run_selfplay_chunk,
+                        chunk,
+                        simulations,
+                        (seed_base ^ (idx * 0x9E3779B1)) & 0x7FFFFFFF,
+                        idx,
+                        progress_queue,
+                    ): idx
+                    for idx, chunk in enumerate(chunks)
+                }
+                pending: set[Future] = set(futures)
+                while pending:
+                    done, pending = wait(pending, timeout=0.2, return_when=FIRST_COMPLETED)
+                    progress_events_seen += self._drain_selfplay_progress(
+                        progress_queue,
+                        progress,
+                        progress_task,
+                        source,
+                        chunk_tasks,
+                    )
+                    if self._should_stop():
+                        for future in pending:
+                            future.cancel()
+                        break
+                    for future in done:
+                        try:
+                            finished = future.result()
+                        except Exception:
+                            logger.exception("Self-play worker failed: source={}", source)
+                            raise
+                        for history_dicts, winner in finished:
+                            history = [
+                                PendingSample(
+                                    board=item["board"],
+                                    to_play=item["to_play"],
+                                    last_action=item["last_action"],
+                                    policy=item["policy"],
+                                )
+                                for item in history_dicts
+                            ]
+                            self.replay.add_game(history, int(winner), self.config.optimization.value_discount)
+                            total_moves += len(history)
+                            black_wins += int(winner == 1)
+                            white_wins += int(winner == -1)
+                            draws += int(winner == 0)
+                            completed_games += 1
+
+                progress_events_seen += self._drain_selfplay_progress(
+                    progress_queue,
+                    progress,
+                    progress_task,
+                    source,
+                    chunk_tasks,
+                )
+            missing_progress = max(0, completed_games - progress_events_seen)
+            if missing_progress:
+                progress.update(progress_task, advance=missing_progress, status=f"{source} games")
+
+        logger.debug(
+            "Self-play source finished (parallel): source={} games={} batch_size={} workers={}",
+            source,
+            completed_games,
+            batch_size,
+            effective_workers,
+        )
+        return {
+            "games": completed_games,
+            "black_wins": black_wins,
+            "white_wins": white_wins,
+            "draws": draws,
+            "total_moves": total_moves,
+        }
+
+    def _drain_selfplay_progress(
+        self,
+        progress_queue: Any,
+        progress: Progress,
+        progress_task: TaskID,
+        source: str,
+        chunk_tasks: dict[int, TaskID] | None = None,
+    ) -> int:
+        drained = 0
+        while True:
+            try:
+                event = progress_queue.get_nowait()
+            except Empty:
+                break
+            if isinstance(event, dict):
+                event_type = event.get("type")
+                chunk_id = int(event.get("chunk_id", -1))
+                chunk_task = None if chunk_tasks is None else chunk_tasks.get(chunk_id)
+                pid = event.get("pid", "?")
+                if event_type == "chunk_started":
+                    self._selfplay_chunk_moves[chunk_id] = 0
+                    if chunk_task is not None:
+                        progress.update(chunk_task, status=f"pid={pid} running")
+                    self._refresh_selfplay_status(progress, progress_task, source)
+                    continue
+                if event_type == "game_moves":
+                    moves_delta = int(event.get("moves", 0))
+                    active = int(event.get("active_games", 0))
+                    self._selfplay_total_moves += moves_delta
+                    self._selfplay_chunk_moves[chunk_id] = (
+                        self._selfplay_chunk_moves.get(chunk_id, 0) + moves_delta
+                    )
+                    if chunk_task is not None:
+                        chunk_moves = self._selfplay_chunk_moves[chunk_id]
+                        progress.update(
+                            chunk_task,
+                            status=f"pid={pid} active={active} moves={chunk_moves}",
+                        )
+                    self._refresh_selfplay_status(progress, progress_task, source)
+                    continue
+                if event_type == "game_done":
+                    drained += 1
+                    moves = event.get("moves", "?")
+                    winner = event.get("winner", "?")
+                    chunk_done = int(event.get("chunk_done", 0))
+                    chunk_size = int(event.get("chunk_size", 0))
+                    if chunk_task is not None:
+                        status = (
+                            "done"
+                            if chunk_size > 0 and chunk_done >= chunk_size
+                            else f"pid={pid} last_moves={moves} winner={winner}"
+                        )
+                        progress.update(chunk_task, advance=1, status=status)
+                    self._selfplay_completed_games += 1
+                    progress.update(progress_task, advance=1)
+                    self._refresh_selfplay_status(progress, progress_task, source)
+                    continue
+            else:
+                drained += 1
+                progress.update(progress_task, advance=1, status=f"{source} games")
+        return drained
+
+    def _refresh_selfplay_status(self, progress: Progress, progress_task: TaskID, source: str) -> None:
+        progress.update(
+            progress_task,
+            status=(
+                f"{source} | moves={self._selfplay_total_moves:,} "
+                f"games_done={self._selfplay_completed_games}"
+            ),
+        )
+
+    def train_model(self) -> dict[str, float | int]:
+        if len(self.replay) == 0:
+            return {"updates_done": 0, "train_loss": 0.0, "policy_loss": 0.0, "value_loss": 0.0}
+
+        batch_size = min(self.config.optimization.batch_size, len(self.replay))
+        total_loss = 0.0
+        total_policy_loss = 0.0
+        total_value_loss = 0.0
+        updates_done = 0
+
+        with make_progress() as progress:
+            progress_task = progress.add_task(
+                "Training",
+                total=self.config.optimization.updates_per_iteration,
+                status="",
+            )
+            self.model.train()
+            for _ in range(self.config.optimization.updates_per_iteration):
+                if self._should_stop():
+                    break
+                update_started = time.perf_counter()
+                states, target_policy, target_value = self.replay.sample_batch_torch(
+                    batch_size,
+                    device=self.torch_device,
+                    recency_temperature=self.config.optimization.recency_temperature,
+                )
+                sample_seconds = time.perf_counter() - update_started
+
+                step_started = time.perf_counter()
+                self.optimizer.zero_grad(set_to_none=True)
+                logits, value = self.model(states)
+                forward_seconds = time.perf_counter() - step_started
+
+                step_started = time.perf_counter()
+                policy_loss = -(target_policy * torch_f_log_softmax(logits, dim=1)).sum(dim=1).mean()
+                value_loss = ((value - target_value) ** 2).mean()
+                loss = (
+                    self.config.optimization.policy_loss_weight * policy_loss
+                    + self.config.optimization.value_loss_weight * value_loss
+                )
+                loss_seconds = time.perf_counter() - step_started
+
+                step_started = time.perf_counter()
+                loss.backward()
+                if self.config.optimization.grad_clip > 0.0:
+                    torch.nn.utils.clip_grad_norm_(
+                        self.model.parameters(),
+                        self.config.optimization.grad_clip,
+                    )
+                backward_seconds = time.perf_counter() - step_started
+
+                step_started = time.perf_counter()
+                self.optimizer.step()
+                optimizer_seconds = time.perf_counter() - step_started
+
+                loss_value = float(loss.detach().cpu().item())
+                policy_loss_value = float(policy_loss.detach().cpu().item())
+                value_loss_value = float(value_loss.detach().cpu().item())
+
+                sync_started = time.perf_counter()
+                torch.cuda.synchronize() if self.torch_device.type == "cuda" else None
+                sync_seconds = time.perf_counter() - sync_started
+                if self.iteration_metrics is not None:
+                    self.iteration_metrics.training.record(
+                        batch_size=batch_size,
+                        sample_seconds=sample_seconds,
+                        forward_seconds=forward_seconds,
+                        loss_seconds=loss_seconds,
+                        backward_seconds=backward_seconds,
+                        optimizer_seconds=optimizer_seconds,
+                        sync_seconds=sync_seconds,
+                    )
+                total_loss += loss_value
+                total_policy_loss += policy_loss_value
+                total_value_loss += value_loss_value
+                updates_done += 1
+                self.total_updates += 1
+                progress.update(progress_task, advance=1, status=f"loss={loss_value:.4f}")
+
+        updates = max(1, updates_done)
+        stats = {
+            "train_loss": round(total_loss / updates, 6),
+            "policy_loss": round(total_policy_loss / updates, 6),
+            "value_loss": round(total_value_loss / updates, 6),
+            "updates_done": updates_done,
+            "learning_rate": self.config.optimization.learning_rate,
+        }
+        logger.info(
+            "Training finished: updates={} loss={:.6f} policy={:.6f} value={:.6f}",
+            updates_done,
+            stats["train_loss"],
+            stats["policy_loss"],
+            stats["value_loss"],
+        )
+        return stats
+
+    def evaluate_candidate(self, selfplay_simulations: int) -> dict[str, float | int | bool | str]:
+        if self.config.arena.games <= 0 or self.config.arena.simulations <= 0:
+            return {
+                "accepted": True,
+                "arena_phase": "disabled",
+                "arena_games": 0,
+                "arena_win_rate": 1.0,
+            }
+
+        phase = "strict"
+        games = self.config.arena.games
+        simulations = self.config.arena.simulations
+        accept_win_rate = self.config.arena.accept_win_rate
+        min_white_win_rate = self.config.arena.min_white_win_rate
+        if self.best_iteration == 0:
+            phase = "bootstrap"
+            games = self.config.arena.bootstrap_games
+            simulations = max(self.config.arena.bootstrap_simulations, selfplay_simulations)
+            accept_win_rate = self.config.arena.bootstrap_accept_win_rate
+            min_white_win_rate = self.config.arena.bootstrap_min_white_win_rate
+
+        candidate_evaluator = self.model_evaluator
+        best_evaluator = self.best_model_evaluator
+        if self.iteration_metrics is not None:
+            if candidate_evaluator is not None:
+                candidate_evaluator = self.iteration_metrics.timed_evaluator("arena_candidate", candidate_evaluator)
+            if best_evaluator is not None:
+                best_evaluator = self.iteration_metrics.timed_evaluator("arena_best", best_evaluator)
+
+        arena = Arena(
+            candidate_model=self.model,
+            best_model=self.best_model,
+            device=self.device,
+            board_size=self.config.rules.board_size,
+            exactly_five=self.config.rules.exactly_five,
+            simulations=simulations,
+            c_puct=self.config.selfplay.c_puct,
+            leaves_per_batch=self.config.selfplay.leaves_per_batch,
+            search_threads=self.config.selfplay.search_threads,
+            virtual_loss=self.config.selfplay.virtual_loss,
+            mcts_backend=self.config.selfplay.mcts_backend,
+            candidate_evaluator=candidate_evaluator,
+            best_evaluator=best_evaluator,
+            metrics=self.iteration_metrics,
+        )
+        result = arena.evaluate(games)
+        side_games = max(1, result.games // 2)
+        candidate_white_win_rate = result.candidate_white_wins / side_games
+        passes_white_gate = candidate_white_win_rate >= min_white_win_rate
+        accepted = result.candidate_win_rate >= accept_win_rate and passes_white_gate
+        return {
+            "accepted": accepted,
+            "arena_phase": phase,
+            "arena_games": result.games,
+            "arena_simulations": simulations,
+            "arena_accept_win_rate": round(accept_win_rate, 4),
+            "arena_white_win_rate_threshold": round(min_white_win_rate, 4),
+            "arena_passes_white_gate": passes_white_gate,
+            "arena_candidate_wins": result.candidate_wins,
+            "arena_best_wins": result.best_wins,
+            "arena_draws": result.draws,
+            "arena_candidate_black_wins": result.candidate_black_wins,
+            "arena_candidate_white_wins": result.candidate_white_wins,
+            "arena_candidate_white_win_rate": round(candidate_white_win_rate, 4),
+            "arena_win_rate": round(result.candidate_win_rate, 4),
+            "arena_avg_moves": round(0.0 if result.games == 0 else result.moves / result.games, 2),
+        }
+
+    def _log_iteration_metrics(self, metadata: dict[str, Any]) -> None:
+        logger.info(
+            "Iteration {} timings: total={:.3f}s selfplay={:.3f}s train={:.3f}s arena={:.3f}s checkpoint={:.3f}s",
+            metadata["iteration"],
+            metadata["duration_seconds"],
+            metadata["selfplay_seconds"],
+            metadata["train_seconds"],
+            metadata["arena_seconds"],
+            metadata["checkpoint_seconds"],
+        )
+        logger.info(
+            "Iteration {} eval: selfplay={:.3f}s/{} calls arena={:.3f}s/{} calls train_sync={:.3f}s",
+            metadata["iteration"],
+            float(metadata.get("eval_selfplay_candidate_seconds", 0.0))
+            + float(metadata.get("eval_selfplay_best_seconds", 0.0)),
+            int(metadata.get("eval_selfplay_candidate_calls", 0))
+            + int(metadata.get("eval_selfplay_best_calls", 0)),
+            float(metadata.get("eval_arena_candidate_seconds", 0.0))
+            + float(metadata.get("eval_arena_best_seconds", 0.0)),
+            int(metadata.get("eval_arena_candidate_calls", 0)) + int(metadata.get("eval_arena_best_calls", 0)),
+            metadata.get("train_sync_seconds", 0.0),
+        )
+
+    def save_model_checkpoints(self, metadata: dict[str, Any]) -> None:
+        latest_metadata = {**metadata, "checkpoint_role": "candidate"}
+        best_metadata = {
+            **self.best_checkpoint_metadata,
+            "checkpoint_role": "best",
+            "best_iteration": self.best_iteration,
+            "best_arena_win_rate": self.best_arena_win_rate,
+        }
+        save_checkpoint(
+            self.checkpoint_dir / "latest.pt",
+            self.model,
+            self.config,
+            latest_metadata,
+            optimizer=self.optimizer,
+        )
+        save_checkpoint(
+            self.checkpoint_dir / "best.pt",
+            self.best_model,
+            self.config,
+            best_metadata,
+            optimizer=None,
+        )
+        save_interval = (
+            1
+            if self.config.checkpoint.save_every_iteration
+            else max(0, self.config.checkpoint.save_iteration_interval)
+        )
+        if save_interval > 0 and self.iteration % save_interval == 0:
+            save_checkpoint(
+                self.checkpoint_dir / f"iter_{self.iteration:04d}.pt",
+                self.model,
+                self.config,
+                latest_metadata,
+                optimizer=self.optimizer,
+            )
+
+    def save_runtime_state(self, metadata: dict[str, Any]) -> None:
+        payload = {
+            **metadata,
+            "iteration": self.iteration,
+            "best_iteration": self.best_iteration,
+            "best_arena_win_rate": self.best_arena_win_rate,
+            "total_updates": self.total_updates,
+            "elapsed_seconds": self.elapsed_seconds_offset + time.monotonic() - self.start_time,
+        }
+        save_trainer_state(self.checkpoint_dir, payload, self.replay.state_dict())
+        self.progress_file.write_text(json.dumps(payload, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    def _restore_from_checkpoint(self, resume_path: str) -> None:
+        path = Path(resume_path)
+        root = path.parent if path.name == "trainer_state.json" else path
+        if path.is_dir() or path.name == "trainer_state.json":
+            metadata, replay_state = load_trainer_state(root)
+            self.model, loaded_config, latest_metadata, latest_optimizer, _ = load_checkpoint(root / "latest")
+            self._validate_resume_config(loaded_config)
+            self._apply_loaded_state(self.model, loaded_config, latest_metadata, latest_optimizer, "latest checkpoint")
+            best_checkpoint = root / "best"
+            best_metadata = None
+            if best_checkpoint.with_suffix(".pt").exists() or best_checkpoint.with_suffix(".safetensors").exists():
+                self.best_model, _, best_metadata, _, _ = load_checkpoint(best_checkpoint)
+            else:
+                self.best_model = clone_model(self.model)
+            if best_metadata:
+                self.best_checkpoint_metadata = dict(best_metadata)
+            if replay_state:
+                self.replay.load_state_dict(replay_state)
+            self.iteration = int(latest_metadata.get("iteration", metadata.get("iteration", 0)))
+            self.best_iteration = int(metadata.get("best_iteration", latest_metadata.get("best_iteration", 0)))
+            self.best_arena_win_rate = float(
+                metadata.get("best_arena_win_rate", latest_metadata.get("best_arena_win_rate", 0.0))
+            )
+            self.total_updates = int(
+                metadata.get("total_updates", latest_metadata.get("total_updates", self.total_updates))
+            )
+            self.elapsed_seconds_offset = float(metadata.get("elapsed_seconds", self.elapsed_seconds_offset))
+            self.start_time = time.monotonic()
+            logger.info(
+                "Resumed trainer state: iteration={} best_iteration={} replay_games={}",
+                self.iteration,
+                self.best_iteration,
+                self.replay.games_seen,
+            )
+            return
+
+        self.model, loaded_config, loaded_metadata, latest_optimizer, _ = load_checkpoint(path)
+        self._validate_resume_config(loaded_config)
+        self._apply_loaded_state(self.model, loaded_config, loaded_metadata, latest_optimizer, "checkpoint file")
+        self.best_model = clone_model(self.model)
+        self.iteration = int(loaded_metadata.get("iteration", 0))
+        self.best_iteration = int(loaded_metadata.get("best_iteration", 0))
+        self.best_arena_win_rate = float(loaded_metadata.get("best_arena_win_rate", self.best_arena_win_rate))
+        self.total_updates = int(loaded_metadata.get("total_updates", self.total_updates))
+        self.elapsed_seconds_offset = float(loaded_metadata.get("elapsed_seconds", self.elapsed_seconds_offset))
+        self.start_time = time.monotonic()
+        logger.info(
+            "Resumed model checkpoint: path={} iteration={}",
+            path,
+            self.iteration,
+        )
+
+    def _apply_loaded_state(
+        self,
+        model: object,
+        loaded_config: RunConfig,
+        metadata: dict[str, Any],
+        optimizer_state: dict[str, Any] | None,
+        checkpoint_label: str,
+    ) -> None:
+        max_iterations_override = self.config.max_iterations
+        max_hours_override = self.config.max_hours
+        self.config = loaded_config
+        if max_iterations_override is not None:
+            self.config.max_iterations = max_iterations_override
+        if max_hours_override is not None:
+            self.config.max_hours = max_hours_override
+        self.model = model.to(self.torch_device)
+        self.optimizer = self._build_optimizer()
+        if optimizer_state is not None:
+            self.optimizer.load_state_dict(optimizer_state)
+        else:
+            logger.warning(
+                "Resuming {}: optimizer state not restored. Continuing with fresh torch optimizer.",
+                checkpoint_label,
+            )
+        if metadata.get("total_updates") is not None:
+            self.total_updates = int(metadata.get("total_updates", 0))
+
+    def _validate_resume_config(self, loaded_config: RunConfig) -> None:
+        if self.config.rules != loaded_config.rules:
+            raise ValueError("resume config rules do not match checkpoint rules")
+        if self.config.network != loaded_config.network:
+            raise ValueError("resume config network does not match checkpoint network")
+
+    def _selfplay_temperature(self, move_count: int) -> float:
+        cfg = self.config.selfplay
+        if cfg.temperature_moves <= 0:
+            return float(cfg.temperature_end)
+        if move_count >= cfg.temperature_moves:
+            return float(cfg.temperature_end)
+        frac = move_count / float(cfg.temperature_moves)
+        return 1.0 + (float(cfg.temperature_end) - 1.0) * frac
+
+    def _should_stop(self) -> bool:
+        if self.stop_requested:
+            return True
+        return self.config.max_hours is not None and self.elapsed_hours >= self.config.max_hours
+
+    def _should_start_iteration(self) -> bool:
+        if self._should_stop():
+            return False
+        return self.config.max_iterations is None or self.iteration < self.config.max_iterations
+
+    def _handle_stop_signal(self, signum: int, _frame: object) -> None:
+        self.stop_requested = True
+        logger.warning("Received stop signal {}", signum)
+
+    def _log(self, payload: dict[str, Any]) -> None:
+        line = json.dumps(payload, ensure_ascii=False)
+        print(line, flush=True)
+        with self.log_file.open("a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+
+
+def build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Train a 15x15 Omok policy/value agent with PyTorch.")
+    parser.add_argument("--config", type=str, default="configs/omok15_quick.yaml")
+    parser.add_argument("--resume", type=str, default=None)
+    parser.add_argument("--max-hours", type=float, default=None)
+    parser.add_argument("--max-iterations", type=int, default=None)
+    parser.add_argument("--device", type=str, default=None)
+    return parser
+
+
+def torch_f_log_softmax(logits: torch.Tensor, dim: int) -> torch.Tensor:
+    return torch.nn.functional.log_softmax(logits, dim=dim)
+
+
+def main() -> None:
+    configure_logging()
+    args = build_argparser().parse_args()
+    config = load_config(args.config)
+    if args.max_hours is not None:
+        config.max_hours = args.max_hours
+    if args.max_iterations is not None:
+        config.max_iterations = args.max_iterations
+    if args.device is not None:
+        config.device = args.device
+    set_seed(config.seed)
+    trainer = Trainer(config=config, resume_path=args.resume)
+    logger.info(
+        "Startup: device={} seed={} torch_training={}",
+        trainer.device,
+        config.seed,
+        True,
+    )
+    trainer.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a dedicated, non-invasive training pipeline for 15x15 Omok so larger-board experiments can be run without changing the existing 9x9 code. 
- Keep 15x15 behavior isolated from `omok` so checkpoints, config defaults, and runtime messaging remain separate. 
- Supply sensible 15x15 hyperparameter presets (full/quick/smoke) as starting points for training and tuning on larger boards. 

### Description
- Added a new package `src/coolrl/omok15` by cloning the existing 9x9 pipeline and adapting it to a fixed 15x15 rule set, including `board`, `config`, `torch_network`, `train`, and plotting code changes to reflect a 15x15 action space. 
- Enforced 15x15 constraints and messages in key modules (e.g. `GameState`/`RulesConfig`/`PolicyValueNet`) and adjusted policy-entropies to `ln(225)`. 
- Restricted the `omok15` MCTS backend to Python-only via `mcts_backend.py` to avoid coupling to the 9x9 C backend, and wired the cloned modules (features, mcts, replay, evaluator, torch_evaluator, etc.) to the new package. 
- Added config presets `configs/omok15_full_cuda.yaml`, `configs/omok15_quick.yaml`, and `configs/omok15_smoke.yaml`, added CLI entrypoints `omok15-train` and `omok15-plot` in `pyproject.toml`, and pointed the `omok15` trainer default config to `configs/omok15_quick.yaml`. 

### Testing
- Ran Python bytecode compilation with `python -m compileall src/coolrl/omok15 configs/omok15_full_cuda.yaml configs/omok15_quick.yaml configs/omok15_smoke.yaml`, which succeeded. 
- Performed a smoke import/run attempt with `PYTHONPATH=src python ...` to instantiate `omok15` classes, which failed in this environment due to a missing dependency: `ModuleNotFoundError: No module named 'yaml'` (missing `pyyaml`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e690d4b62c8324b50b550d583f2659)