### PR TITLE
Recover evaluator on visibility change (mobile WebKit); add healthCheck and test; unify ORT graph optimization

### DIFF
--- a/src/coolrl/omok/web/src/app/omok-controller.ts
+++ b/src/coolrl/omok/web/src/app/omok-controller.ts
@@ -109,6 +109,8 @@ export class OmokController {
   private defaultModelLoadStarted = false;
   private canvasCtx: CanvasRenderingContext2D | null = null;
   private idleReleaseTimer: ReturnType<typeof setTimeout> | null = null;
+  private visibilityRecoveryPromise: Promise<void> | null = null;
+  private visibilityRecoveryPendingWhenIdle = false;
 
   private readonly stoneAnimations: StoneAnimations;
   private readonly thinkingGhosts: ThinkingGhosts;
@@ -252,7 +254,7 @@ export class OmokController {
     on(document, "dblclick", (e) => e.preventDefault(), { passive: false });
     on(window, "resize", () => this.handleResize());
     on(window, "orientationchange", () => this.handleResize());
-    on(document, "visibilitychange", () => this.debugPanel.syncTimer());
+    on(document, "visibilitychange", () => this.handleVisibilityChange());
     on(this.dom.debugPanel, "toggle", () => this.debugPanel.syncTimer());
 
     const themeObserver = new MutationObserver(() => this.redraw());
@@ -415,6 +417,60 @@ export class OmokController {
         });
       });
     }, 400);
+  }
+
+  private handleVisibilityChange(): void {
+    this.debugPanel.syncTimer();
+    if (document.visibilityState !== "visible") return;
+    if (!this.env.isMobile || !this.env.isWebKit) return;
+    if (this.busy) {
+      this.visibilityRecoveryPendingWhenIdle = true;
+      logDebug("OmokController", "visibilityRecovery.deferredWhileBusy");
+      return;
+    }
+    void this.recoverEvaluatorAfterForeground();
+  }
+
+  private async recoverEvaluatorAfterForeground(): Promise<void> {
+    if (this.visibilityRecoveryPromise) {
+      await this.visibilityRecoveryPromise;
+      return;
+    }
+    this.visibilityRecoveryPromise = (async () => {
+      if (this.busy) return;
+      const evaluator = this.evaluator;
+      if (!evaluator) return;
+      try {
+        await evaluator.healthCheck();
+        logDebug("OmokController", "visibilityRecovery.healthCheck.ok");
+        return;
+      } catch (err) {
+        logWarn("OmokController", "visibilityRecovery.healthCheck.failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      if (this.evaluator !== evaluator) return;
+      try {
+        await this.disposeEvaluatorAsync();
+        this.mcts = null;
+        const buf = await this.fetchModelBuffer();
+        this.evaluator = await this.createEvaluator(buf);
+        this.mcts = this.makeMcts();
+        this.aiSubtree = null;
+        this.updateInfo();
+        this.debugPanel.render();
+        logInfo("OmokController", "visibilityRecovery.reinitialized");
+      } catch (err) {
+        logError("OmokController", "visibilityRecovery.reinitialize.failed", err);
+        this.statusPresenter.flash(`백그라운드 복귀 후 복구 실패${errorChipDetail(err)}`, "error", 8000);
+        this.updateInfo();
+      }
+    })();
+    try {
+      await this.visibilityRecoveryPromise;
+    } finally {
+      this.visibilityRecoveryPromise = null;
+    }
   }
 
   private async handleFileInput(e: Event & { target: HTMLInputElement }): Promise<void> {
@@ -775,6 +831,7 @@ export class OmokController {
 
   private setBusy(busy: boolean): void {
     logDebug("OmokController", "setBusy", { busy });
+    const wasBusy = this.busy;
     this.busy = busy;
     this.dom.btnReset.disabled = busy;
     this.dom.btnSettings.disabled = busy;
@@ -784,6 +841,18 @@ export class OmokController {
     this.dom.btnAi.disabled =
       busy || !this.hasModel() || this.game.terminal || !this.isHumanTurn();
     this.dom.btnConfirm.disabled = busy || this.pendingAction === null;
+    if (
+      wasBusy &&
+      !busy &&
+      this.visibilityRecoveryPendingWhenIdle &&
+      document.visibilityState === "visible" &&
+      this.env.isMobile &&
+      this.env.isWebKit
+    ) {
+      this.visibilityRecoveryPendingWhenIdle = false;
+      logDebug("OmokController", "visibilityRecovery.runDeferred");
+      void this.recoverEvaluatorAfterForeground();
+    }
   }
 
   private openSheet(): void {

--- a/src/coolrl/omok/web/src/evaluator/worker-evaluator.test.ts
+++ b/src/coolrl/omok/web/src/evaluator/worker-evaluator.test.ts
@@ -25,6 +25,17 @@ vi.mock("./worker?worker", () => {
           this.onmessage?.({
             data: { id: message.id, ok: true, backend: message.backend ?? "wasm" },
           } as MessageEvent);
+        } else if (message.type === "evaluate") {
+          this.onmessage?.({
+            data: {
+              id: message.id,
+              ok: true,
+              policy: new Float32Array([1]).buffer,
+              values: new Float32Array([0]).buffer,
+              batch: 1,
+              actionSize: 1,
+            },
+          } as MessageEvent);
         } else if (message.type === "dispose") {
           this.onmessage?.({
             data: { id: message.id, ok: true, disposed: true },
@@ -82,5 +93,20 @@ describe("WorkerEvaluator.dispose", () => {
     sent.length = 0;
     await expect(evaluator.dispose()).resolves.toBeUndefined();
     expect(sent.filter((m) => m.type === "dispose")).toHaveLength(0);
+  });
+});
+
+describe("WorkerEvaluator.healthCheck", () => {
+  it("sends a lightweight evaluate request", async () => {
+    sent.length = 0;
+    const { WorkerEvaluator } = await import("./worker-evaluator");
+    const buf = new ArrayBuffer(16);
+    const evaluator = await WorkerEvaluator.fromArrayBuffer(buf, 15);
+
+    sent.length = 0;
+    await evaluator.healthCheck();
+
+    expect(sent.filter((m) => m.type === "evaluate")).toHaveLength(1);
+    await evaluator.dispose();
   });
 });

--- a/src/coolrl/omok/web/src/evaluator/worker-evaluator.ts
+++ b/src/coolrl/omok/web/src/evaluator/worker-evaluator.ts
@@ -143,6 +143,20 @@ export class WorkerEvaluator implements Evaluator {
     return { policy, value };
   }
 
+  async healthCheck(): Promise<void> {
+    if (!this.worker) throw new Error("evaluator not initialized");
+    const dummy: StateSnapshot = {
+      boardSize: this.boardSize,
+      board: new Int8Array(this.actionSize),
+      toPlay: 1,
+      lastAction: null,
+    };
+    await this.send({
+      type: "evaluate",
+      states: [dummy],
+    });
+  }
+
   private send(
     request: { type: string } & Record<string, unknown>,
     transfer: Transferable[] = []

--- a/src/coolrl/omok/web/src/evaluator/worker.ts
+++ b/src/coolrl/omok/web/src/evaluator/worker.ts
@@ -154,7 +154,7 @@ class EvaluatorSession {
   private buildSessionOptions(backend: InferenceBackend, lowMemory: boolean) {
     const options = {
       executionProviders: [backend],
-      graphOptimizationLevel: lowMemory ? ("basic" as const) : ("all" as const),
+      graphOptimizationLevel: "all" as const,
     };
     if (backend === "wasm") {
       return {


### PR DESCRIPTION
### Motivation

- Ensure the in-page evaluator recovers reliably after the page returns to the foreground on mobile WebKit where backgrounding can make the worker/wasm/GPU resources unhealthy.
- Provide a lightweight API to verify worker/evaluator health and reinitialize the evaluator when needed.
- Simplify ORT session options by unifying the graph optimization level.

### Description

- Add visibility handling in `OmokController`: replace the simple `visibilitychange` handler with `handleVisibilityChange`, which defers recovery when busy and triggers `recoverEvaluatorAfterForeground` to health-check and, if necessary, reinitialize the evaluator and MCTS; integrate deferred recovery with `setBusy` to run once the controller becomes idle.
- Implement `WorkerEvaluator.healthCheck()` which sends a lightweight `evaluate` request with a dummy snapshot to validate worker/ORT health and surface failures for recovery logic.
- Update the worker mock in `worker-evaluator.test.ts` to respond to `evaluate` messages and add a unit test verifying `WorkerEvaluator.healthCheck()` sends an `evaluate` request.
- Change ORT session option `graphOptimizationLevel` to always use `"all"` in `evaluator/worker.ts` to remove conditional branching on `lowMemory` for that flag.

### Testing

- Ran the unit tests for the evaluator (`vitest` for `worker-evaluator.test.ts`) and the new `WorkerEvaluator.healthCheck` test passed.
- Existing evaluator tests (dispose/fromArrayBuffer) were executed and passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8028390e883248d9e280289ea4401)