### PR TITLE
exactly_five 규칙을 웹/훈련 기본값으로 통일

### DIFF
--- a/src/coolrl/omok/board.py
+++ b/src/coolrl/omok/board.py
@@ -11,7 +11,7 @@ Action = int
 @dataclass(slots=True)
 class GameState:
     board_size: int = 9
-    exactly_five: bool = False
+    exactly_five: bool = True
     board: np.ndarray | None = None
     to_play: int = 1
     move_count: int = 0

--- a/src/coolrl/omok/config.py
+++ b/src/coolrl/omok/config.py
@@ -11,7 +11,7 @@ import yaml
 @dataclass(slots=True)
 class RulesConfig:
     board_size: int = 9
-    exactly_five: bool = False
+    exactly_five: bool = True
 
     def __post_init__(self) -> None:
         self.board_size = int(self.board_size)

--- a/src/coolrl/omok/web/src/core/game-state.test.ts
+++ b/src/coolrl/omok/web/src/core/game-state.test.ts
@@ -106,6 +106,45 @@ describe("GameState.clone", () => {
     expect(copy.moveCount).toBe(2);
     expect(g.board[1]).toBe(0);
   });
+
+  it("preserves the exactlyFive flag", () => {
+    const strict = new GameState(15, true);
+    const relaxed = new GameState(15, false);
+    expect(strict.clone().exactlyFive).toBe(true);
+    expect(relaxed.clone().exactlyFive).toBe(false);
+  });
+});
+
+describe("GameState exactly-five rule", () => {
+  // Build a 6-in-a-row for black at row 0, columns 0..5, ending with
+  // black filling the gap at (0,4). White plays spaced stones on row 2
+  // so it never forms its own line.
+  // Black: (0,0..3),(0,5),(0,4)  White: (2,0),(2,2),(2,4),(2,6),(2,8)
+  const overlineMoves = [0, 30, 1, 32, 2, 34, 3, 36, 5, 38, 4];
+
+  it("defaults to exactly-five (overline is not a win)", () => {
+    const g = new GameState(15);
+    expect(g.exactlyFive).toBe(true);
+    playSequence(g, overlineMoves);
+    expect(g.terminal).toBe(false);
+    expect(g.winner).toBe(0);
+    for (const col of [0, 1, 2, 3, 4, 5]) expect(g.board[col]).toBe(1);
+  });
+
+  it("with exactlyFive=false, overline counts as a win", () => {
+    const g = new GameState(15, false);
+    expect(g.exactlyFive).toBe(false);
+    playSequence(g, overlineMoves);
+    expect(g.terminal).toBe(true);
+    expect(g.winner).toBe(1);
+  });
+
+  it("still detects clean 5-in-a-row under exactlyFive=true", () => {
+    const g = new GameState(15, true);
+    playSequence(g, [0, 15, 1, 16, 2, 17, 3, 18, 4]);
+    expect(g.terminal).toBe(true);
+    expect(g.winner).toBe(1);
+  });
 });
 
 describe("outcomeForPlayer", () => {

--- a/src/coolrl/omok/web/src/core/game-state.ts
+++ b/src/coolrl/omok/web/src/core/game-state.ts
@@ -11,6 +11,7 @@ const DIRECTIONS: ReadonlyArray<readonly [number, number]> = [
 export class GameState {
   readonly boardSize: number;
   readonly actionSize: number;
+  readonly exactlyFive: boolean;
   readonly board: Int8Array;
   toPlay: Player;
   moveCount: number;
@@ -18,9 +19,10 @@ export class GameState {
   winner: Player | 0;
   terminal: boolean;
 
-  constructor(boardSize = 9) {
+  constructor(boardSize = 9, exactlyFive = true) {
     this.boardSize = boardSize;
     this.actionSize = boardSize * boardSize;
+    this.exactlyFive = exactlyFive;
     this.board = new Int8Array(this.actionSize);
     this.toPlay = 1;
     this.moveCount = 0;
@@ -30,7 +32,7 @@ export class GameState {
   }
 
   clone(): GameState {
-    const copy = new GameState(this.boardSize);
+    const copy = new GameState(this.boardSize, this.exactlyFive);
     copy.board.set(this.board);
     copy.toPlay = this.toPlay;
     copy.moveCount = this.moveCount;
@@ -86,7 +88,7 @@ export class GameState {
         1 +
         this.countDirection(row, col, dr, dc, player) +
         this.countDirection(row, col, -dr, -dc, player);
-      if (count >= 5) return true;
+      if (this.exactlyFive ? count === 5 : count >= 5) return true;
     }
     return false;
   }


### PR DESCRIPTION
웹의 GameState는 overline(6목 이상)도 승리로 처리했고 훈련
기본값은 exactly_five=false 여서, 배포된 모델과 웹 규칙이 어긋날
수 있었다. 양쪽 모두 기본값을 exactly_five=true 로 맞추고 웹에
overline 규칙을 검증하는 테스트를 추가한다.

https://claude.ai/code/session_01BdHFwaTtDTw3q9xQp2nXBq