### PR TITLE
Optimize Lost Cities Deep CFR traversal and profiling

### DIFF
--- a/configs/lost_cities_deep_cfr_probe.yaml
+++ b/configs/lost_cities_deep_cfr_probe.yaml
@@ -25,10 +25,15 @@ traversal:
   backend: python
   traversals_per_player: 10
   strategy_sample_interval: 1
+  store_strategy_on_opponent_nodes: true
+  store_strategy_on_traverser_nodes: true
   max_depth: 12
-  max_nodes_per_traversal: 10000
-  progress_every_traversals: 2
+  max_nodes_per_traversal: 5000
+  progress_every_traversals: 1
   num_workers: 0
+  traversal_worker_chunk_size: 1
+  # Enable to write encode/forward/clone/apply/memory timing breakdowns into metrics.
+  profile_hotspots: false
   regret_matching_epsilon: 1.0e-8
 
 optimization:
@@ -45,6 +50,8 @@ memory:
   strategy_capacity: 5000
 
 evaluation:
+  # Set eval_every: 0 to disable evaluation entirely for fast probe runs.
+  # Keep games small when using this profile for timing or smoke tests.
   eval_every: 1
   games: 1
   opponents:
@@ -54,4 +61,5 @@ checkpoint:
   directory: checkpoints/lost_cities_deep_cfr_probe
   save_every_iteration: true
   save_iteration_interval: 1
+  save_latest_only: false
   progress_interval_seconds: 20.0

--- a/configs/lost_cities_deep_cfr_probe.yaml
+++ b/configs/lost_cities_deep_cfr_probe.yaml
@@ -27,11 +27,15 @@ traversal:
   strategy_sample_interval: 1
   store_strategy_on_opponent_nodes: true
   store_strategy_on_traverser_nodes: true
+  # Hard node cap for one traversal. When the budget is exhausted mid-expansion,
+  # remaining traverser actions use the current score_diff(traverser) fallback.
   max_depth: 12
   max_nodes_per_traversal: 5000
   progress_every_traversals: 1
   num_workers: 0
-  traversal_worker_chunk_size: 1
+  # Start around 4-5 when enabling multiprocessing; chunk_size=1 pays the
+  # frozen state_dict serialization and CPU model reconstruction cost every batch.
+  traversal_worker_chunk_size: 4
   # Enable to write encode/forward/clone/apply/memory timing breakdowns into metrics.
   profile_hotspots: false
   regret_matching_epsilon: 1.0e-8
@@ -52,6 +56,8 @@ memory:
 evaluation:
   # Set eval_every: 0 to disable evaluation entirely for fast probe runs.
   # Keep games small when using this profile for timing or smoke tests.
+  # Use `python -m coolrl.lost_cities.deep_cfr.cli benchmark-traversal ...`
+  # to compare workers=0 vs multiprocessing traversal_seconds on the same setup.
   eval_every: 1
   games: 1
   opponents:

--- a/configs/lost_cities_deep_cfr_small_run.yaml
+++ b/configs/lost_cities_deep_cfr_small_run.yaml
@@ -25,10 +25,14 @@ traversal:
   backend: python
   traversals_per_player: 10
   strategy_sample_interval: 1
+  store_strategy_on_opponent_nodes: true
+  store_strategy_on_traverser_nodes: true
   max_depth: 12
   max_nodes_per_traversal: 10000
   progress_every_traversals: 2
   num_workers: 0
+  traversal_worker_chunk_size: 1
+  profile_hotspots: false
   regret_matching_epsilon: 1.0e-8
 
 optimization:
@@ -55,4 +59,5 @@ checkpoint:
   directory: checkpoints/lost_cities_deep_cfr_small_run
   save_every_iteration: true
   save_iteration_interval: 1
+  save_latest_only: false
   progress_interval_seconds: 20.0

--- a/configs/lost_cities_deep_cfr_small_run.yaml
+++ b/configs/lost_cities_deep_cfr_small_run.yaml
@@ -27,11 +27,14 @@ traversal:
   strategy_sample_interval: 1
   store_strategy_on_opponent_nodes: true
   store_strategy_on_traverser_nodes: true
+  # Hard node cap for one traversal. When the budget is exhausted mid-expansion,
+  # remaining traverser actions use the current score_diff(traverser) fallback.
   max_depth: 12
   max_nodes_per_traversal: 10000
   progress_every_traversals: 2
   num_workers: 0
-  traversal_worker_chunk_size: 1
+  # If num_workers > 1, prefer 4-5 instead of 1 to amortize worker setup costs.
+  traversal_worker_chunk_size: 4
   profile_hotspots: false
   regret_matching_epsilon: 1.0e-8
 

--- a/configs/lost_cities_deep_cfr_tier3.yaml
+++ b/configs/lost_cities_deep_cfr_tier3.yaml
@@ -27,12 +27,16 @@ traversal:
   strategy_sample_interval: 1
   store_strategy_on_opponent_nodes: true
   store_strategy_on_traverser_nodes: true
+  # Hard node cap for one traversal. When the budget is exhausted mid-expansion,
+  # remaining traverser actions use the current score_diff(traverser) fallback.
   max_depth: 8
   max_nodes_per_traversal: 10000
   progress_every_traversals: 10
   num_workers: 0
   # For Ryzen 5600X, try num_workers: 4 after smoke tests pass.
-  traversal_worker_chunk_size: 1
+  # Prefer 4-5 when multiprocessing is enabled so each worker batch amortizes
+  # frozen state_dict shipping and CPU model reconstruction.
+  traversal_worker_chunk_size: 4
   profile_hotspots: false
   regret_matching_epsilon: 1.0e-8
 

--- a/configs/lost_cities_deep_cfr_tier3.yaml
+++ b/configs/lost_cities_deep_cfr_tier3.yaml
@@ -25,10 +25,15 @@ traversal:
   backend: python
   traversals_per_player: 100
   strategy_sample_interval: 1
+  store_strategy_on_opponent_nodes: true
+  store_strategy_on_traverser_nodes: true
   max_depth: 8
   max_nodes_per_traversal: 10000
   progress_every_traversals: 10
   num_workers: 0
+  # For Ryzen 5600X, try num_workers: 4 after smoke tests pass.
+  traversal_worker_chunk_size: 1
+  profile_hotspots: false
   regret_matching_epsilon: 1.0e-8
 
 optimization:
@@ -55,4 +60,5 @@ checkpoint:
   directory: checkpoints/lost_cities_deep_cfr_tier3
   save_every_iteration: true
   save_iteration_interval: 1
+  save_latest_only: false
   progress_interval_seconds: 20.0

--- a/src/coolrl/lost_cities/deep_cfr/benchmark.py
+++ b/src/coolrl/lost_cities/deep_cfr/benchmark.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .config import RunConfig, config_from_dict
+from .trainer import DeepCFRTrainer
+
+
+@dataclass(slots=True)
+class TraversalBenchmarkResult:
+    num_workers: int
+    traversal_seconds: float
+    total_nodes: int
+    traversals: int
+    nodes_per_second: float
+    avg_nodes_per_traversal: float
+
+
+def _benchmark_config_variant(config: RunConfig, *, num_workers: int, checkpoint_dir: Path) -> RunConfig:
+    payload = config.to_dict()
+    # Force CPU traversal in both modes so the comparison measures multiprocessing
+    # speedup rather than CUDA transfer behavior or mixed CPU/GPU traversal paths.
+    payload["device"] = "cpu"
+    payload["max_iterations"] = 0
+    payload.setdefault("evaluation", {})
+    payload["evaluation"]["eval_every"] = 0
+    payload.setdefault("checkpoint", {})
+    payload["checkpoint"]["directory"] = str(checkpoint_dir)
+    payload["checkpoint"]["save_latest_only"] = True
+    payload.setdefault("traversal", {})
+    payload["traversal"]["num_workers"] = int(num_workers)
+    payload["traversal"]["progress_every_traversals"] = 0
+    payload["traversal"]["profile_hotspots"] = False
+    return config_from_dict(payload)
+
+
+def _run_traversal_benchmark_once(config: RunConfig, *, iteration: int) -> TraversalBenchmarkResult:
+    trainer = DeepCFRTrainer(config)
+    started = time.monotonic()
+    if trainer.num_workers <= 1:
+        total_stats, traversals, _ = trainer._run_traversals_single_process(iteration)
+    else:
+        total_stats, traversals, _ = trainer._run_traversals_parallel(iteration)
+    traversal_seconds = time.monotonic() - started
+    return TraversalBenchmarkResult(
+        num_workers=trainer.num_workers,
+        traversal_seconds=traversal_seconds,
+        total_nodes=total_stats.nodes,
+        traversals=traversals,
+        nodes_per_second=total_stats.nodes / max(1.0e-9, traversal_seconds),
+        avg_nodes_per_traversal=total_stats.nodes / max(1, traversals),
+    )
+
+
+def benchmark_traversal_modes(
+    config: RunConfig,
+    *,
+    mp_workers: int,
+    iteration: int = 1,
+) -> dict[str, Any]:
+    if mp_workers <= 1:
+        raise ValueError(f"mp_workers must be > 1 for comparison benchmarking, got {mp_workers}")
+
+    with tempfile.TemporaryDirectory(prefix="lost_cities_deep_cfr_benchmark_") as temp_dir:
+        base_dir = Path(temp_dir)
+        single = _run_traversal_benchmark_once(
+            _benchmark_config_variant(config, num_workers=0, checkpoint_dir=base_dir / "single"),
+            iteration=iteration,
+        )
+        multiprocessing = _run_traversal_benchmark_once(
+            _benchmark_config_variant(config, num_workers=mp_workers, checkpoint_dir=base_dir / "multi"),
+            iteration=iteration,
+        )
+
+    return {
+        "device_used": "cpu",
+        "iteration": iteration,
+        "single_process": {
+            "num_workers": single.num_workers,
+            "traversal_seconds": single.traversal_seconds,
+            "total_nodes": single.total_nodes,
+            "traversals": single.traversals,
+            "nodes_per_second": single.nodes_per_second,
+            "avg_nodes_per_traversal": single.avg_nodes_per_traversal,
+        },
+        "multiprocessing": {
+            "num_workers": multiprocessing.num_workers,
+            "traversal_seconds": multiprocessing.traversal_seconds,
+            "total_nodes": multiprocessing.total_nodes,
+            "traversals": multiprocessing.traversals,
+            "nodes_per_second": multiprocessing.nodes_per_second,
+            "avg_nodes_per_traversal": multiprocessing.avg_nodes_per_traversal,
+        },
+        "speedup_vs_single_process": single.traversal_seconds / max(1.0e-9, multiprocessing.traversal_seconds),
+    }

--- a/src/coolrl/lost_cities/deep_cfr/cli.py
+++ b/src/coolrl/lost_cities/deep_cfr/cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import torch
 from loguru import logger
 
+from .benchmark import benchmark_traversal_modes
 from .config import config_from_dict, load_config
 from .evaluate import evaluate_against_bot, make_opponent
 from .networks import StrategyNet
@@ -57,6 +58,43 @@ def eval_command(args: argparse.Namespace) -> None:
     )
 
 
+def benchmark_traversal_command(args: argparse.Namespace) -> None:
+    config = load_config(args.config)
+    result = benchmark_traversal_modes(
+        config,
+        mp_workers=args.mp_workers,
+        iteration=args.iteration,
+    )
+    single = result["single_process"]
+    multiprocessing = result["multiprocessing"]
+    logger.info(
+        "Traversal benchmark uses device={} for both modes so the comparison reflects traversal multiprocessing overhead/speedup.",
+        result["device_used"],
+    )
+    logger.info(
+        "Single-process: workers={} traversal_seconds={:.4f} total_nodes={} traversals={} avg_nodes_per_traversal={:.1f} nodes_per_second={:.1f}",
+        single["num_workers"],
+        single["traversal_seconds"],
+        single["total_nodes"],
+        single["traversals"],
+        single["avg_nodes_per_traversal"],
+        single["nodes_per_second"],
+    )
+    logger.info(
+        "Multiprocessing: workers={} traversal_seconds={:.4f} total_nodes={} traversals={} avg_nodes_per_traversal={:.1f} nodes_per_second={:.1f}",
+        multiprocessing["num_workers"],
+        multiprocessing["traversal_seconds"],
+        multiprocessing["total_nodes"],
+        multiprocessing["traversals"],
+        multiprocessing["avg_nodes_per_traversal"],
+        multiprocessing["nodes_per_second"],
+    )
+    logger.info(
+        "Traversal benchmark speedup vs single-process: {:.3f}x",
+        result["speedup_vs_single_process"],
+    )
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="python -m coolrl.lost_cities.deep_cfr.cli")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -72,6 +110,12 @@ def build_parser() -> argparse.ArgumentParser:
     eval_parser.add_argument("--games", type=int, default=100)
     eval_parser.add_argument("--opponent", choices=["random", "safe_heuristic"], default="random")
     eval_parser.set_defaults(func=eval_command)
+
+    benchmark = subparsers.add_parser("benchmark-traversal")
+    benchmark.add_argument("--config", type=Path, default=Path("configs/lost_cities_deep_cfr_probe.yaml"))
+    benchmark.add_argument("--mp-workers", type=int, default=2)
+    benchmark.add_argument("--iteration", type=int, default=1)
+    benchmark.set_defaults(func=benchmark_traversal_command)
     return parser
 
 

--- a/src/coolrl/lost_cities/deep_cfr/config.py
+++ b/src/coolrl/lost_cities/deep_cfr/config.py
@@ -50,10 +50,14 @@ class TraversalConfig:
     backend: str = "python"
     traversals_per_player: int = 100
     strategy_sample_interval: int = 1
+    store_strategy_on_opponent_nodes: bool = True
+    store_strategy_on_traverser_nodes: bool = True
     max_depth: int | None = 8
     max_nodes_per_traversal: int | None = 10_000
     progress_every_traversals: int = 10
     num_workers: int | str = 0
+    traversal_worker_chunk_size: int = 1
+    profile_hotspots: bool = False
     regret_matching_epsilon: float = 1.0e-8
 
     def resolved_num_workers(self) -> tuple[int, bool]:
@@ -98,6 +102,7 @@ class CheckpointConfig:
     directory: str = "checkpoints/lost_cities_deep_cfr_tier3"
     save_every_iteration: bool = True
     save_iteration_interval: int = 1
+    save_latest_only: bool = False
     progress_interval_seconds: float = 20.0
 
 

--- a/src/coolrl/lost_cities/deep_cfr/config.py
+++ b/src/coolrl/lost_cities/deep_cfr/config.py
@@ -56,7 +56,7 @@ class TraversalConfig:
     max_nodes_per_traversal: int | None = 10_000
     progress_every_traversals: int = 10
     num_workers: int | str = 0
-    traversal_worker_chunk_size: int = 1
+    traversal_worker_chunk_size: int = 4
     profile_hotspots: bool = False
     regret_matching_epsilon: float = 1.0e-8
 

--- a/src/coolrl/lost_cities/deep_cfr/memory.py
+++ b/src/coolrl/lost_cities/deep_cfr/memory.py
@@ -62,6 +62,17 @@ class _ReservoirMemory:
             "iteration": np.asarray([sample.iteration for sample in batch], dtype=np.int64),
         }
 
+    def extend_samples(self, samples: list[_Sample], rng: np.random.Generator) -> None:
+        for sample in samples:
+            self._add_sample(
+                sample.info_state,
+                sample.target,
+                sample.legal_mask,
+                sample.player,
+                sample.iteration,
+                rng,
+            )
+
 
 class AdvantageMemory(_ReservoirMemory):
     def add(

--- a/src/coolrl/lost_cities/deep_cfr/trainer.py
+++ b/src/coolrl/lost_cities/deep_cfr/trainer.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import copy
+from concurrent.futures import ProcessPoolExecutor, as_completed
 import json
+import multiprocessing as mp
 import random
 import shutil
 import time
@@ -18,7 +21,12 @@ from .encoding import infer_input_dim
 from .evaluate import evaluate_against_bot, make_opponent
 from .memory import AdvantageMemory, StrategyMemory
 from .networks import AdvantageNet, StrategyNet
-from .traversal import DeepCFRTraverser, TraversalStats
+from .traversal import DeepCFRTraverser, TraversalStats, TraversalTimingStats
+from .traversal_worker import (
+    TraversalWorkerBatch,
+    TraversalWorkerBatchResult,
+    _run_traversal_worker_batch,
+)
 
 
 def _torch_device(name: str) -> torch.device:
@@ -76,11 +84,8 @@ class DeepCFRTrainer:
         self.metrics_path = self.checkpoint_dir / "metrics.jsonl"
         self.progress_path = self.checkpoint_dir / "runtime_progress.json"
         self.num_workers, _ = config.traversal.resolved_num_workers()
-        if self.num_workers != 0:
-            logger.warning(
-                "traversal.num_workers={} is ignored by the Python Deep CFR MVP; traversals run in-process",
-                self.num_workers,
-            )
+        self.traversal_worker_chunk_size = max(1, int(config.traversal.traversal_worker_chunk_size))
+        self.profile_hotspots = bool(config.traversal.profile_hotspots)
         if resume_path is None and self.metrics_path.exists():
             archive = self.metrics_path.with_name(f"metrics.{time.strftime('%Y%m%d-%H%M%S')}.jsonl")
             shutil.move(self.metrics_path, archive)
@@ -109,7 +114,8 @@ class DeepCFRTrainer:
             self._append_metrics(metrics)
             self._write_progress(metrics)
             if self._should_save(self.iteration):
-                self.save_checkpoint(self.checkpoint_dir / f"iteration_{self.iteration:05d}.pt", metrics)
+                if not self.config.checkpoint.save_latest_only:
+                    self.save_checkpoint(self.checkpoint_dir / f"iteration_{self.iteration:05d}.pt", metrics)
                 self.save_checkpoint(self.checkpoint_dir / "latest.pt", metrics)
 
     def _should_continue(self) -> bool:
@@ -127,44 +133,10 @@ class DeepCFRTrainer:
 
     def run_iteration(self, iteration: int) -> dict[str, Any]:
         traversal_started = time.monotonic()
-        total_stats = TraversalStats()
-        traverser = DeepCFRTraverser(
-            self.advantage_nets,
-            self.advantage_memories,
-            self.strategy_memory,
-            device=self.device,
-            epsilon=self.config.traversal.regret_matching_epsilon,
-            strategy_sample_interval=self.config.traversal.strategy_sample_interval,
-            max_depth=self.config.traversal.max_depth,
-            max_nodes_per_traversal=self.config.traversal.max_nodes_per_traversal,
-            rng=self.rng,
-        )
-        traversals = 0
-        for player in (0, 1):
-            self.advantage_nets[player].eval()
-            player_traversal_started = time.monotonic()
-            for index in range(self.config.traversal.traversals_per_player):
-                seed = self.config.seed + iteration * 1_000_003 + player * 100_003 + index
-                state = GameState.new_game(self.lc_config, seed=seed)
-                _, stats = traverser.traverse(state, player, iteration)
-                total_stats.nodes += stats.nodes
-                total_stats.terminals += stats.terminals
-                total_stats.cutoffs += stats.cutoffs
-                total_stats.node_limit_cutoffs += stats.node_limit_cutoffs
-                total_stats.max_depth_reached = max(total_stats.max_depth_reached, stats.max_depth_reached)
-                traversals += 1
-                progress_every = self.config.traversal.progress_every_traversals
-                if progress_every > 0 and (index + 1) % progress_every == 0:
-                    elapsed = time.monotonic() - player_traversal_started
-                    avg_nodes = total_stats.nodes / max(1, traversals)
-                    logger.info(
-                        "Traversal progress: player={} completed={} elapsed_seconds={:.2f} total_nodes={} avg_nodes_per_traversal={:.1f}",
-                        player,
-                        index + 1,
-                        elapsed,
-                        total_stats.nodes,
-                        avg_nodes,
-                    )
+        if self.num_workers <= 1:
+            total_stats, traversals, hotspot_stats = self._run_traversals_single_process(iteration)
+        else:
+            total_stats, traversals, hotspot_stats = self._run_traversals_parallel(iteration)
         traversal_seconds = time.monotonic() - traversal_started
 
         adv_started = time.monotonic()
@@ -221,6 +193,8 @@ class DeepCFRTrainer:
             "strategy_loss": strategy_loss,
             **eval_metrics,
         }
+        if hotspot_stats is not None:
+            metrics.update(self._hotspot_metrics(hotspot_stats))
         logger.info(
             "Iteration {}: nodes={} cutoffs={} node_limit_cutoffs={} cutoff_rate={:.4f} node_limit_cutoff_rate={:.4f} nps={:.1f} adv_loss=({:.4f},{:.4f}) strategy_loss={:.4f}",
             iteration,
@@ -234,7 +208,226 @@ class DeepCFRTrainer:
             advantage_losses[1],
             strategy_loss,
         )
+        if hotspot_stats is not None:
+            logger.info(
+                "Traversal hotspots: wall={:.3f}s encode={:.3f}s forward={:.3f}s regret={:.3f}s clone_apply={:.3f}s memory_add={:.3f}s policy_calls={} clone_apply_calls={} memory_add_calls={}",
+                hotspot_stats.traversal_wall_seconds,
+                hotspot_stats.encode_information_state_seconds,
+                hotspot_stats.advantage_forward_seconds,
+                hotspot_stats.regret_matching_seconds,
+                hotspot_stats.clone_apply_seconds,
+                hotspot_stats.memory_add_seconds,
+                hotspot_stats.policy_calls,
+                hotspot_stats.clone_apply_calls,
+                hotspot_stats.memory_add_calls,
+            )
         return metrics
+
+    def _traversal_seed(self, iteration: int, player: int, index: int) -> int:
+        return self.config.seed + iteration * 1_000_003 + player * 100_003 + index
+
+    def _hotspot_metrics(self, hotspot_stats: TraversalTimingStats) -> dict[str, Any]:
+        return {
+            "traversal_profile_wall_seconds": hotspot_stats.traversal_wall_seconds,
+            "traversal_profile_encode_seconds": hotspot_stats.encode_information_state_seconds,
+            "traversal_profile_forward_seconds": hotspot_stats.advantage_forward_seconds,
+            "traversal_profile_regret_matching_seconds": hotspot_stats.regret_matching_seconds,
+            "traversal_profile_clone_apply_seconds": hotspot_stats.clone_apply_seconds,
+            "traversal_profile_memory_add_seconds": hotspot_stats.memory_add_seconds,
+            "traversal_profile_policy_calls": hotspot_stats.policy_calls,
+            "traversal_profile_clone_apply_calls": hotspot_stats.clone_apply_calls,
+            "traversal_profile_memory_add_calls": hotspot_stats.memory_add_calls,
+        }
+
+    def _run_traversals_single_process(self, iteration: int) -> tuple[TraversalStats, int, TraversalTimingStats | None]:
+        total_stats = TraversalStats()
+        hotspot_stats = TraversalTimingStats() if self.profile_hotspots else None
+        traverser = DeepCFRTraverser(
+            self.advantage_nets,
+            self.advantage_memories,
+            self.strategy_memory,
+            device=self.device,
+            epsilon=self.config.traversal.regret_matching_epsilon,
+            strategy_sample_interval=self.config.traversal.strategy_sample_interval,
+            store_strategy_on_opponent_nodes=self.config.traversal.store_strategy_on_opponent_nodes,
+            store_strategy_on_traverser_nodes=self.config.traversal.store_strategy_on_traverser_nodes,
+            max_depth=self.config.traversal.max_depth,
+            max_nodes_per_traversal=self.config.traversal.max_nodes_per_traversal,
+            rng=self.rng,
+            timing_stats=hotspot_stats,
+        )
+        traversals = 0
+        for player in (0, 1):
+            self.advantage_nets[player].eval()
+            player_traversal_started = time.monotonic()
+            for index in range(self.config.traversal.traversals_per_player):
+                seed = self._traversal_seed(iteration, player, index)
+                state = GameState.new_game(self.lc_config, seed=seed)
+                _, stats = traverser.traverse(state, player, iteration)
+                total_stats.nodes += stats.nodes
+                total_stats.terminals += stats.terminals
+                total_stats.cutoffs += stats.cutoffs
+                total_stats.node_limit_cutoffs += stats.node_limit_cutoffs
+                total_stats.max_depth_reached = max(total_stats.max_depth_reached, stats.max_depth_reached)
+                traversals += 1
+                progress_every = self.config.traversal.progress_every_traversals
+                if progress_every > 0 and (index + 1) % progress_every == 0:
+                    elapsed = time.monotonic() - player_traversal_started
+                    avg_nodes = total_stats.nodes / max(1, traversals)
+                    logger.info(
+                        "Traversal progress: player={} completed={} elapsed_seconds={:.2f} total_nodes={} avg_nodes_per_traversal={:.1f}",
+                        player,
+                        index + 1,
+                        elapsed,
+                        total_stats.nodes,
+                        avg_nodes,
+                    )
+        return total_stats, traversals, hotspot_stats
+
+    def _frozen_advantage_state_dicts(self) -> list[dict[str, Any]]:
+        frozen_state_dicts: list[dict[str, Any]] = []
+        for net in self.advantage_nets:
+            net.eval()
+            frozen_state_dicts.append(
+                {
+                    name: value.detach().cpu().clone() if isinstance(value, torch.Tensor) else copy.deepcopy(value)
+                    for name, value in net.state_dict().items()
+                }
+            )
+        return frozen_state_dicts
+
+    def _build_traversal_worker_batches(
+        self,
+        iteration: int,
+        advantage_net_state_dicts: list[dict[str, Any]],
+    ) -> list[TraversalWorkerBatch]:
+        batches: list[TraversalWorkerBatch] = []
+        batch_index = 0
+        for player in (0, 1):
+            seeds = [
+                self._traversal_seed(iteration, player, index)
+                for index in range(self.config.traversal.traversals_per_player)
+            ]
+            for start in range(0, len(seeds), self.traversal_worker_chunk_size):
+                chunk = seeds[start : start + self.traversal_worker_chunk_size]
+                batches.append(
+                    TraversalWorkerBatch(
+                        batch_index=batch_index,
+                        lc_config_snapshot=self.lc_config.to_snapshot(),
+                        input_dim=self.input_dim,
+                        action_size=self.action_size,
+                        network_config=self.config.network,
+                        advantage_net_state_dicts=advantage_net_state_dicts,
+                        traverser=player,
+                        iteration=iteration,
+                        seeds=chunk,
+                        max_depth=self.config.traversal.max_depth,
+                        max_nodes_per_traversal=self.config.traversal.max_nodes_per_traversal,
+                        strategy_sample_interval=self.config.traversal.strategy_sample_interval,
+                        store_strategy_on_opponent_nodes=self.config.traversal.store_strategy_on_opponent_nodes,
+                        store_strategy_on_traverser_nodes=self.config.traversal.store_strategy_on_traverser_nodes,
+                        profile_hotspots=self.profile_hotspots,
+                        regret_matching_epsilon=self.config.traversal.regret_matching_epsilon,
+                        worker_seed=self.config.seed + iteration * 10_000_019 + player * 1_000_003 + batch_index,
+                    )
+                )
+                batch_index += 1
+        return batches
+
+    def _merge_advantage_samples(self, player: int, samples: list[Any]) -> None:
+        if samples:
+            self.advantage_memories[player].extend_samples(samples, self.rng)
+
+    def _merge_strategy_samples(self, samples: list[Any]) -> None:
+        if samples:
+            self.strategy_memory.extend_samples(samples, self.rng)
+
+    def _accumulate_parallel_traversal_result(
+        self,
+        total_stats: TraversalStats,
+        result: TraversalWorkerBatchResult,
+        hotspot_stats: TraversalTimingStats | None = None,
+    ) -> int:
+        total_stats.nodes += result.stats.nodes
+        total_stats.terminals += result.stats.terminals
+        total_stats.cutoffs += result.stats.cutoffs
+        total_stats.node_limit_cutoffs += result.stats.node_limit_cutoffs
+        total_stats.max_depth_reached = max(total_stats.max_depth_reached, result.stats.max_depth_reached)
+        self._merge_advantage_samples(result.traverser, result.advantage_samples)
+        self._merge_strategy_samples(result.strategy_samples)
+        if hotspot_stats is not None:
+            hotspot_stats.accumulate(result.timing_stats)
+        return result.seeds_completed
+
+    def _merge_parallel_traversal_results(
+        self,
+        results: list[TraversalWorkerBatchResult],
+    ) -> tuple[TraversalStats, int]:
+        total_stats = TraversalStats()
+        traversals = 0
+        for result in sorted(results, key=lambda item: item.batch_index):
+            traversals += self._accumulate_parallel_traversal_result(total_stats, result)
+        return total_stats, traversals
+
+    def _run_traversals_parallel(self, iteration: int) -> tuple[TraversalStats, int, TraversalTimingStats | None]:
+        advantage_net_state_dicts = self._frozen_advantage_state_dicts()
+        batches = self._build_traversal_worker_batches(iteration, advantage_net_state_dicts)
+        if not batches:
+            return TraversalStats(), 0, TraversalTimingStats() if self.profile_hotspots else None
+
+        max_workers = min(self.num_workers, len(batches))
+        logger.info(
+            "Traversal multiprocessing enabled: num_workers={} batches={} chunk_size={}",
+            max_workers,
+            len(batches),
+            self.traversal_worker_chunk_size,
+        )
+
+        total_stats = TraversalStats()
+        traversals = 0
+        hotspot_stats = TraversalTimingStats() if self.profile_hotspots else None
+        pending_results: dict[int, TraversalWorkerBatchResult] = {}
+        next_batch_index = 0
+        progress_nodes = 0
+        progress_traversals = 0
+        progress_every = self.config.traversal.progress_every_traversals
+        next_progress_at = progress_every if progress_every > 0 else None
+        progress_started = time.monotonic()
+        with ProcessPoolExecutor(
+            max_workers=max_workers,
+            mp_context=mp.get_context("spawn"),
+        ) as executor:
+            futures = [executor.submit(_run_traversal_worker_batch, batch) for batch in batches]
+            total_batches = len(futures)
+            for completed_batches, future in enumerate(as_completed(futures), start=1):
+                result = future.result()
+                pending_results[result.batch_index] = result
+                progress_nodes += result.stats.nodes
+                progress_traversals += result.seeds_completed
+                elapsed = time.monotonic() - progress_started
+                if next_progress_at is not None and progress_traversals >= next_progress_at:
+                    avg_nodes = progress_nodes / max(1, progress_traversals)
+                    nodes_per_second = progress_nodes / max(1.0e-9, elapsed)
+                    logger.info(
+                        "Traversal multiprocessing progress: num_workers={} completed_batches={}/{} elapsed_seconds={:.2f} total_nodes={} avg_nodes_per_traversal={:.1f} nodes_per_second={:.1f}",
+                        max_workers,
+                        completed_batches,
+                        total_batches,
+                        elapsed,
+                        progress_nodes,
+                        avg_nodes,
+                        nodes_per_second,
+                    )
+                    while next_progress_at is not None and next_progress_at <= progress_traversals:
+                        next_progress_at += progress_every
+                while next_batch_index in pending_results:
+                    traversals += self._accumulate_parallel_traversal_result(
+                        total_stats,
+                        pending_results.pop(next_batch_index),
+                        hotspot_stats,
+                    )
+                    next_batch_index += 1
+        return total_stats, traversals, hotspot_stats
 
     def _train_advantage(self, player: int, updates: int) -> float:
         memory = self.advantage_memories[player]

--- a/src/coolrl/lost_cities/deep_cfr/traversal.py
+++ b/src/coolrl/lost_cities/deep_cfr/traversal.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import time
 
 import numpy as np
 import torch
@@ -20,6 +21,32 @@ class TraversalStats:
     max_depth_reached: int = 0
 
 
+@dataclass(slots=True)
+class TraversalTimingStats:
+    traversal_wall_seconds: float = 0.0
+    encode_information_state_seconds: float = 0.0
+    advantage_forward_seconds: float = 0.0
+    regret_matching_seconds: float = 0.0
+    clone_apply_seconds: float = 0.0
+    memory_add_seconds: float = 0.0
+    policy_calls: int = 0
+    clone_apply_calls: int = 0
+    memory_add_calls: int = 0
+
+    def accumulate(self, other: TraversalTimingStats | None) -> None:
+        if other is None:
+            return
+        self.traversal_wall_seconds += other.traversal_wall_seconds
+        self.encode_information_state_seconds += other.encode_information_state_seconds
+        self.advantage_forward_seconds += other.advantage_forward_seconds
+        self.regret_matching_seconds += other.regret_matching_seconds
+        self.clone_apply_seconds += other.clone_apply_seconds
+        self.memory_add_seconds += other.memory_add_seconds
+        self.policy_calls += other.policy_calls
+        self.clone_apply_calls += other.clone_apply_calls
+        self.memory_add_calls += other.memory_add_calls
+
+
 def clone_state(state: GameState) -> GameState:
     return state.clone()
 
@@ -34,9 +61,12 @@ class DeepCFRTraverser:
         device: torch.device,
         epsilon: float = 1.0e-8,
         strategy_sample_interval: int = 1,
+        store_strategy_on_opponent_nodes: bool = True,
+        store_strategy_on_traverser_nodes: bool = True,
         max_depth: int | None = None,
         max_nodes_per_traversal: int | None = None,
         rng: np.random.Generator | None = None,
+        timing_stats: TraversalTimingStats | None = None,
     ) -> None:
         self.advantage_nets = advantage_nets
         self.advantage_memories = advantage_memories
@@ -44,22 +74,46 @@ class DeepCFRTraverser:
         self.device = device
         self.epsilon = float(epsilon)
         self.strategy_sample_interval = max(1, int(strategy_sample_interval))
+        self.store_strategy_on_opponent_nodes = bool(store_strategy_on_opponent_nodes)
+        self.store_strategy_on_traverser_nodes = bool(store_strategy_on_traverser_nodes)
         self.max_depth = max_depth
         self.max_nodes_per_traversal = max_nodes_per_traversal
         self.rng = rng or np.random.default_rng()
+        self.timing_stats = timing_stats
 
     def traverse(self, state: GameState, traverser: int, iteration: int) -> tuple[float, TraversalStats]:
         stats = TraversalStats()
+        if self.timing_stats is None:
+            value = self._traverse(state, traverser, iteration, 0, stats)
+            return value, stats
+        started = time.perf_counter()
         value = self._traverse(state, traverser, iteration, 0, stats)
+        self.timing_stats.traversal_wall_seconds += time.perf_counter() - started
         return value, stats
 
     def _policy(self, state: GameState, player: int) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        if self.timing_stats is None:
+            info = encode_information_state(state, player)
+            legal = legal_mask_array(state)
+            with torch.inference_mode():
+                x = torch.as_tensor(info, dtype=torch.float32, device=self.device).unsqueeze(0)
+                advantages = self.advantage_nets[player](x).squeeze(0).detach().cpu().numpy()
+            policy = regret_matching(advantages, legal, self.epsilon)
+            return info, legal, np.asarray(policy, dtype=np.float32)
+
+        self.timing_stats.policy_calls += 1
+        started = time.perf_counter()
         info = encode_information_state(state, player)
+        self.timing_stats.encode_information_state_seconds += time.perf_counter() - started
         legal = legal_mask_array(state)
-        with torch.no_grad():
+        started = time.perf_counter()
+        with torch.inference_mode():
             x = torch.as_tensor(info, dtype=torch.float32, device=self.device).unsqueeze(0)
             advantages = self.advantage_nets[player](x).squeeze(0).detach().cpu().numpy()
+        self.timing_stats.advantage_forward_seconds += time.perf_counter() - started
+        started = time.perf_counter()
         policy = regret_matching(advantages, legal, self.epsilon)
+        self.timing_stats.regret_matching_seconds += time.perf_counter() - started
         return info, legal, np.asarray(policy, dtype=np.float32)
 
     def _record_strategy(
@@ -68,11 +122,36 @@ class DeepCFRTraverser:
         legal: np.ndarray,
         policy: np.ndarray,
         player: int,
+        traverser: int,
         iteration: int,
         depth: int,
     ) -> None:
-        if depth % self.strategy_sample_interval == 0:
+        if player == traverser:
+            if not self.store_strategy_on_traverser_nodes:
+                return
+        elif not self.store_strategy_on_opponent_nodes:
+            return
+        if depth % self.strategy_sample_interval != 0:
+            return
+        if self.timing_stats is None:
             self.strategy_memory.add(info, policy, legal, player, iteration, self.rng)
+            return
+        started = time.perf_counter()
+        self.strategy_memory.add(info, policy, legal, player, iteration, self.rng)
+        self.timing_stats.memory_add_seconds += time.perf_counter() - started
+        self.timing_stats.memory_add_calls += 1
+
+    def _child_after_action(self, state: GameState, action: int) -> GameState:
+        if self.timing_stats is None:
+            child = clone_state(state)
+            child.apply_unified_action(action)
+            return child
+        started = time.perf_counter()
+        child = clone_state(state)
+        child.apply_unified_action(action)
+        self.timing_stats.clone_apply_seconds += time.perf_counter() - started
+        self.timing_stats.clone_apply_calls += 1
+        return child
 
     def _traverse(
         self,
@@ -97,7 +176,7 @@ class DeepCFRTraverser:
 
         player = state.current_player
         info, legal, policy = self._policy(state, player)
-        self._record_strategy(info, legal, policy, player, iteration, depth)
+        self._record_strategy(info, legal, policy, player, traverser, iteration, depth)
         legal_actions = np.flatnonzero(legal)
         if len(legal_actions) == 0:
             stats.terminals += 1
@@ -106,8 +185,7 @@ class DeepCFRTraverser:
         if player == traverser:
             action_values = np.zeros(state.action_size, dtype=np.float32)
             for action in legal_actions:
-                child = clone_state(state)
-                child.apply_unified_action(int(action))
+                child = self._child_after_action(state, int(action))
                 action_values[action] = self._traverse(
                     child,
                     traverser,
@@ -117,19 +195,31 @@ class DeepCFRTraverser:
                 )
             node_value = float(np.dot(policy, action_values))
             regrets = np.where(legal, action_values - node_value, 0.0).astype(np.float32)
-            self.advantage_memories[traverser].add(
-                info,
-                regrets,
-                legal,
-                traverser,
-                iteration,
-                self.rng,
-            )
+            if self.timing_stats is None:
+                self.advantage_memories[traverser].add(
+                    info,
+                    regrets,
+                    legal,
+                    traverser,
+                    iteration,
+                    self.rng,
+                )
+            else:
+                started = time.perf_counter()
+                self.advantage_memories[traverser].add(
+                    info,
+                    regrets,
+                    legal,
+                    traverser,
+                    iteration,
+                    self.rng,
+                )
+                self.timing_stats.memory_add_seconds += time.perf_counter() - started
+                self.timing_stats.memory_add_calls += 1
             return node_value
 
         action = int(self.rng.choice(legal_actions, p=policy[legal_actions] / policy[legal_actions].sum()))
-        child = clone_state(state)
-        child.apply_unified_action(action)
+        child = self._child_after_action(state, action)
         return self._traverse(
             child,
             traverser,
@@ -149,9 +239,13 @@ def cfr_traverse(
     *,
     device: torch.device | None = None,
     epsilon: float = 1.0e-8,
+    strategy_sample_interval: int = 1,
+    store_strategy_on_opponent_nodes: bool = True,
+    store_strategy_on_traverser_nodes: bool = True,
     max_depth: int | None = None,
     max_nodes_per_traversal: int | None = None,
     rng: np.random.Generator | None = None,
+    timing_stats: TraversalTimingStats | None = None,
 ) -> tuple[float, TraversalStats]:
     traverser_obj = DeepCFRTraverser(
         advantage_nets,
@@ -159,8 +253,12 @@ def cfr_traverse(
         strategy_memory,
         device=device or torch.device("cpu"),
         epsilon=epsilon,
+        strategy_sample_interval=strategy_sample_interval,
+        store_strategy_on_opponent_nodes=store_strategy_on_opponent_nodes,
+        store_strategy_on_traverser_nodes=store_strategy_on_traverser_nodes,
         max_depth=max_depth,
         max_nodes_per_traversal=max_nodes_per_traversal,
         rng=rng,
+        timing_stats=timing_stats,
     )
     return traverser_obj.traverse(state, traverser, iteration)

--- a/src/coolrl/lost_cities/deep_cfr/traversal.py
+++ b/src/coolrl/lost_cities/deep_cfr/traversal.py
@@ -81,6 +81,9 @@ class DeepCFRTraverser:
         self.rng = rng or np.random.default_rng()
         self.timing_stats = timing_stats
 
+    def _node_budget_reached(self, stats: TraversalStats) -> bool:
+        return self.max_nodes_per_traversal is not None and stats.nodes >= self.max_nodes_per_traversal
+
     def traverse(self, state: GameState, traverser: int, iteration: int) -> tuple[float, TraversalStats]:
         stats = TraversalStats()
         if self.timing_stats is None:
@@ -162,7 +165,7 @@ class DeepCFRTraverser:
         stats: TraversalStats,
     ) -> float:
         stats.nodes += 1
-        if self.max_nodes_per_traversal is not None and stats.nodes >= self.max_nodes_per_traversal:
+        if self._node_budget_reached(stats):
             stats.node_limit_cutoffs += 1
             return float(state.score_diff(traverser))
         stats.max_depth_reached = max(stats.max_depth_reached, depth)
@@ -184,7 +187,16 @@ class DeepCFRTraverser:
 
         if player == traverser:
             action_values = np.zeros(state.action_size, dtype=np.float32)
-            for action in legal_actions:
+            fallback_value = float(state.score_diff(traverser))
+            for index, action in enumerate(legal_actions):
+                if self._node_budget_reached(stats):
+                    remaining_actions = legal_actions[index:]
+                    action_values[remaining_actions] = fallback_value
+                    # Treat every unexpanded traverser action as a budget cutoff
+                    # without recursing further, so max_nodes_per_traversal acts as
+                    # a hard cap instead of a soft budget.
+                    stats.node_limit_cutoffs += len(remaining_actions)
+                    break
                 child = self._child_after_action(state, int(action))
                 action_values[action] = self._traverse(
                     child,

--- a/src/coolrl/lost_cities/deep_cfr/traversal_worker.py
+++ b/src/coolrl/lost_cities/deep_cfr/traversal_worker.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import torch
+
+from ..game import GameState, LostCitiesConfig
+from .config import NetworkConfig
+from .memory import _Sample, AdvantageMemory, StrategyMemory
+from .networks import AdvantageNet
+from .traversal import DeepCFRTraverser, TraversalStats, TraversalTimingStats
+
+_UNBOUNDED_WORKER_MEMORY_CAPACITY = 2_147_483_647
+_TORCH_THREADS_CONFIGURED = False
+
+
+@dataclass(slots=True)
+class TraversalWorkerBatch:
+    batch_index: int
+    lc_config_snapshot: dict[str, Any]
+    input_dim: int
+    action_size: int
+    network_config: NetworkConfig
+    advantage_net_state_dicts: list[dict[str, Any]]
+    traverser: int
+    iteration: int
+    seeds: list[int]
+    max_depth: int | None
+    max_nodes_per_traversal: int | None
+    strategy_sample_interval: int
+    store_strategy_on_opponent_nodes: bool
+    store_strategy_on_traverser_nodes: bool
+    profile_hotspots: bool
+    regret_matching_epsilon: float
+    worker_seed: int
+
+
+@dataclass(slots=True)
+class TraversalWorkerBatchResult:
+    batch_index: int
+    traverser: int
+    seeds_completed: int
+    stats: TraversalStats
+    advantage_samples: list[_Sample]
+    strategy_samples: list[_Sample]
+    timing_stats: TraversalTimingStats | None = None
+
+
+def _worker_memory_capacity(batch: TraversalWorkerBatch) -> int:
+    if batch.max_nodes_per_traversal is not None and batch.max_nodes_per_traversal > 0:
+        return max(1, int(batch.max_nodes_per_traversal) * max(1, len(batch.seeds)))
+    return _UNBOUNDED_WORKER_MEMORY_CAPACITY
+
+
+def _configure_worker_torch_threads() -> None:
+    global _TORCH_THREADS_CONFIGURED
+    if _TORCH_THREADS_CONFIGURED:
+        return
+    os.environ.setdefault("OMP_NUM_THREADS", "1")
+    os.environ.setdefault("MKL_NUM_THREADS", "1")
+    torch.set_num_threads(1)
+    if hasattr(torch, "set_num_interop_threads"):
+        try:
+            torch.set_num_interop_threads(1)
+        except RuntimeError:
+            pass
+    _TORCH_THREADS_CONFIGURED = True
+
+
+def _run_traversal_worker_batch(batch: TraversalWorkerBatch) -> TraversalWorkerBatchResult:
+    _configure_worker_torch_threads()
+
+    lc_config = LostCitiesConfig(**batch.lc_config_snapshot)
+    lc_config.validate()
+
+    # Traversal is node-by-node inference. Workers always reconstruct CPU models,
+    # even when the trainer process is using CUDA for network training.
+    device = torch.device("cpu")
+    advantage_nets: list[AdvantageNet] = []
+    for state_dict in batch.advantage_net_state_dicts:
+        net = AdvantageNet(batch.input_dim, batch.action_size, batch.network_config).to(device)
+        cpu_state_dict = {
+            name: value.detach().cpu() if isinstance(value, torch.Tensor) else value
+            for name, value in state_dict.items()
+        }
+        net.load_state_dict(cpu_state_dict)
+        net.eval()
+        advantage_nets.append(net)
+
+    memory_capacity = _worker_memory_capacity(batch)
+    advantage_memories = [
+        AdvantageMemory(memory_capacity),
+        AdvantageMemory(memory_capacity),
+    ]
+    strategy_memory = StrategyMemory(memory_capacity)
+    rng = np.random.default_rng(batch.worker_seed)
+    timing_stats = TraversalTimingStats() if batch.profile_hotspots else None
+    traverser = DeepCFRTraverser(
+        advantage_nets,
+        advantage_memories,
+        strategy_memory,
+        device=device,
+        epsilon=batch.regret_matching_epsilon,
+        strategy_sample_interval=batch.strategy_sample_interval,
+        store_strategy_on_opponent_nodes=batch.store_strategy_on_opponent_nodes,
+        store_strategy_on_traverser_nodes=batch.store_strategy_on_traverser_nodes,
+        max_depth=batch.max_depth,
+        max_nodes_per_traversal=batch.max_nodes_per_traversal,
+        rng=rng,
+        timing_stats=timing_stats,
+    )
+
+    total_stats = TraversalStats()
+    for seed in batch.seeds:
+        state = GameState.new_game(lc_config, seed=seed)
+        _, stats = traverser.traverse(state, batch.traverser, batch.iteration)
+        total_stats.nodes += stats.nodes
+        total_stats.terminals += stats.terminals
+        total_stats.cutoffs += stats.cutoffs
+        total_stats.node_limit_cutoffs += stats.node_limit_cutoffs
+        total_stats.max_depth_reached = max(total_stats.max_depth_reached, stats.max_depth_reached)
+
+    return TraversalWorkerBatchResult(
+        batch_index=batch.batch_index,
+        traverser=batch.traverser,
+        seeds_completed=len(batch.seeds),
+        stats=total_stats,
+        advantage_samples=list(advantage_memories[batch.traverser].samples),
+        strategy_samples=list(strategy_memory.samples),
+        timing_stats=timing_stats,
+    )

--- a/src/coolrl/lost_cities/tests/test_deep_cfr_config.py
+++ b/src/coolrl/lost_cities/tests/test_deep_cfr_config.py
@@ -20,7 +20,7 @@ def test_load_yaml_profile() -> None:
     assert cfg.traversal.max_nodes_per_traversal == 10_000
     assert cfg.traversal.progress_every_traversals == 10
     assert cfg.traversal.num_workers == 0
-    assert cfg.traversal.traversal_worker_chunk_size == 1
+    assert cfg.traversal.traversal_worker_chunk_size == 4
     assert cfg.traversal.profile_hotspots is False
     assert cfg.checkpoint.save_latest_only is False
 
@@ -33,7 +33,7 @@ def test_load_probe_yaml_profile() -> None:
     assert cfg.traversal.max_nodes_per_traversal == 5_000
     assert cfg.traversal.progress_every_traversals == 1
     assert cfg.traversal.num_workers == 0
-    assert cfg.traversal.traversal_worker_chunk_size == 1
+    assert cfg.traversal.traversal_worker_chunk_size == 4
     assert cfg.traversal.profile_hotspots is False
     assert cfg.checkpoint.save_latest_only is False
 

--- a/src/coolrl/lost_cities/tests/test_deep_cfr_config.py
+++ b/src/coolrl/lost_cities/tests/test_deep_cfr_config.py
@@ -15,15 +15,27 @@ def test_load_yaml_profile() -> None:
     cfg = load_config(Path("configs/lost_cities_deep_cfr_tier3.yaml"))
     assert cfg.experiment_name == "lost_cities_deep_cfr_tier3"
     assert cfg.traversal.backend == "python"
+    assert cfg.traversal.store_strategy_on_opponent_nodes is True
+    assert cfg.traversal.store_strategy_on_traverser_nodes is True
     assert cfg.traversal.max_nodes_per_traversal == 10_000
     assert cfg.traversal.progress_every_traversals == 10
+    assert cfg.traversal.num_workers == 0
+    assert cfg.traversal.traversal_worker_chunk_size == 1
+    assert cfg.traversal.profile_hotspots is False
+    assert cfg.checkpoint.save_latest_only is False
 
 
 def test_load_probe_yaml_profile() -> None:
     cfg = load_config(Path("configs/lost_cities_deep_cfr_probe.yaml"))
     assert cfg.rules.tier == "tier3"
+    assert cfg.traversal.store_strategy_on_opponent_nodes is True
+    assert cfg.traversal.store_strategy_on_traverser_nodes is True
     assert cfg.traversal.max_nodes_per_traversal == 5_000
     assert cfg.traversal.progress_every_traversals == 1
+    assert cfg.traversal.num_workers == 0
+    assert cfg.traversal.traversal_worker_chunk_size == 1
+    assert cfg.traversal.profile_hotspots is False
+    assert cfg.checkpoint.save_latest_only is False
 
 
 def test_rules_config_default_tier3_shape() -> None:

--- a/src/coolrl/lost_cities/tests/test_deep_cfr_smoke.py
+++ b/src/coolrl/lost_cities/tests/test_deep_cfr_smoke.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import numpy as np
 import torch
 
+from coolrl.lost_cities.deep_cfr.benchmark import benchmark_traversal_modes
 from coolrl.lost_cities.deep_cfr.config import config_from_dict
 from coolrl.lost_cities.deep_cfr.encoding import infer_input_dim
 from coolrl.lost_cities.deep_cfr.evaluate import StrategyNetBot
@@ -53,7 +54,7 @@ def test_tiny_training_run_completes_with_parallel_traversal(tmp_path: Path) -> 
                 "max_depth": 2,
                 "max_nodes_per_traversal": 32,
                 "num_workers": 2,
-                "traversal_worker_chunk_size": 1,
+                "traversal_worker_chunk_size": 4,
             },
             "optimization": {
                 "advantage_batch_size": 8,
@@ -112,6 +113,38 @@ def test_tiny_training_run_profiles_hotspots_and_can_save_latest_only(tmp_path: 
     assert progress["traversal_profile_regret_matching_seconds"] >= 0.0
     assert progress["traversal_profile_clone_apply_seconds"] >= 0.0
     assert progress["traversal_profile_memory_add_seconds"] >= 0.0
+
+
+def test_traversal_benchmark_compares_single_and_multiprocessing(tmp_path: Path) -> None:
+    cfg = config_from_dict(
+        {
+            "max_iterations": 0,
+            "device": "cpu",
+            "network": {"hidden_size": 16, "num_layers": 1},
+            "traversal": {
+                "traversals_per_player": 1,
+                "max_depth": 2,
+                "max_nodes_per_traversal": 32,
+                "num_workers": 2,
+                "traversal_worker_chunk_size": 4,
+            },
+            "optimization": {
+                "advantage_updates_per_iteration": 0,
+                "strategy_updates_per_iteration": 0,
+            },
+            "evaluation": {"eval_every": 0, "games": 1},
+            "checkpoint": {"directory": str(tmp_path)},
+        }
+    )
+
+    result = benchmark_traversal_modes(cfg, mp_workers=2, iteration=1)
+
+    assert result["device_used"] == "cpu"
+    assert result["single_process"]["num_workers"] == 0
+    assert result["multiprocessing"]["num_workers"] == 2
+    assert result["single_process"]["traversal_seconds"] >= 0.0
+    assert result["multiprocessing"]["traversal_seconds"] >= 0.0
+    assert result["speedup_vs_single_process"] >= 0.0
 
 
 def test_parallel_traversal_result_merge_aggregates_stats(tmp_path: Path) -> None:

--- a/src/coolrl/lost_cities/tests/test_deep_cfr_smoke.py
+++ b/src/coolrl/lost_cities/tests/test_deep_cfr_smoke.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
+import numpy as np
 import torch
 
 from coolrl.lost_cities.deep_cfr.config import config_from_dict
+from coolrl.lost_cities.deep_cfr.encoding import infer_input_dim
 from coolrl.lost_cities.deep_cfr.evaluate import StrategyNetBot
+from coolrl.lost_cities.deep_cfr.memory import _Sample
 from coolrl.lost_cities.deep_cfr.trainer import DeepCFRTrainer
+from coolrl.lost_cities.deep_cfr.traversal import TraversalStats
+from coolrl.lost_cities.deep_cfr.traversal_worker import TraversalWorkerBatchResult
 from coolrl.lost_cities.game import GameState
 
 
@@ -34,6 +40,137 @@ def test_tiny_training_run_completes(tmp_path: Path) -> None:
     assert checkpoint_path.exists()
     checkpoint = torch.load(checkpoint_path, map_location="cpu")
     assert checkpoint["resume_semantics"] == "networks_optimizers_iteration_only"
+
+
+def test_tiny_training_run_completes_with_parallel_traversal(tmp_path: Path) -> None:
+    cfg = config_from_dict(
+        {
+            "max_iterations": 1,
+            "device": "cpu",
+            "network": {"hidden_size": 16, "num_layers": 1},
+            "traversal": {
+                "traversals_per_player": 2,
+                "max_depth": 2,
+                "max_nodes_per_traversal": 32,
+                "num_workers": 2,
+                "traversal_worker_chunk_size": 1,
+            },
+            "optimization": {
+                "advantage_batch_size": 8,
+                "strategy_batch_size": 8,
+                "advantage_updates_per_iteration": 1,
+                "strategy_updates_per_iteration": 1,
+            },
+            "memory": {"advantage_capacity": 100, "strategy_capacity": 100},
+            "evaluation": {"eval_every": 0, "games": 2},
+            "checkpoint": {"directory": str(tmp_path)},
+        }
+    )
+    trainer = DeepCFRTrainer(cfg)
+    trainer.run()
+    checkpoint_path = tmp_path / "latest.pt"
+    assert checkpoint_path.exists()
+    checkpoint = torch.load(checkpoint_path, map_location="cpu")
+    assert checkpoint["resume_semantics"] == "networks_optimizers_iteration_only"
+    assert len(trainer.advantage_memories[0]) > 0 or len(trainer.advantage_memories[1]) > 0
+    assert len(trainer.strategy_memory) > 0
+
+
+def test_tiny_training_run_profiles_hotspots_and_can_save_latest_only(tmp_path: Path) -> None:
+    cfg = config_from_dict(
+        {
+            "max_iterations": 1,
+            "device": "cpu",
+            "network": {"hidden_size": 16, "num_layers": 1},
+            "traversal": {
+                "traversals_per_player": 2,
+                "max_depth": 2,
+                "progress_every_traversals": 0,
+                "profile_hotspots": True,
+            },
+            "optimization": {
+                "advantage_batch_size": 8,
+                "strategy_batch_size": 8,
+                "advantage_updates_per_iteration": 1,
+                "strategy_updates_per_iteration": 1,
+            },
+            "memory": {"advantage_capacity": 100, "strategy_capacity": 100},
+            "evaluation": {"eval_every": 0, "games": 2},
+            "checkpoint": {"directory": str(tmp_path), "save_latest_only": True},
+        }
+    )
+    trainer = DeepCFRTrainer(cfg)
+    trainer.run()
+
+    assert (tmp_path / "latest.pt").exists()
+    assert not (tmp_path / "iteration_00001.pt").exists()
+
+    progress = json.loads((tmp_path / "runtime_progress.json").read_text(encoding="utf-8"))
+    assert progress["traversal_profile_wall_seconds"] >= 0.0
+    assert progress["traversal_profile_encode_seconds"] >= 0.0
+    assert progress["traversal_profile_forward_seconds"] >= 0.0
+    assert progress["traversal_profile_regret_matching_seconds"] >= 0.0
+    assert progress["traversal_profile_clone_apply_seconds"] >= 0.0
+    assert progress["traversal_profile_memory_add_seconds"] >= 0.0
+
+
+def test_parallel_traversal_result_merge_aggregates_stats(tmp_path: Path) -> None:
+    cfg = config_from_dict(
+        {
+            "max_iterations": 0,
+            "device": "cpu",
+            "network": {"hidden_size": 16, "num_layers": 1},
+            "memory": {"advantage_capacity": 10, "strategy_capacity": 10},
+            "checkpoint": {"directory": str(tmp_path)},
+        }
+    )
+    trainer = DeepCFRTrainer(cfg)
+    input_dim = infer_input_dim(trainer.lc_config)
+    legal_mask = np.zeros(trainer.action_size, dtype=bool)
+    legal_mask[0] = True
+
+    def make_sample(player: int, iteration: int, value: float) -> _Sample:
+        target = np.zeros(trainer.action_size, dtype=np.float32)
+        target[0] = value
+        return _Sample(
+            info_state=np.full(input_dim, value, dtype=np.float32),
+            target=target,
+            legal_mask=legal_mask.copy(),
+            player=player,
+            iteration=iteration,
+        )
+
+    first_result = TraversalWorkerBatchResult(
+        batch_index=1,
+        traverser=0,
+        seeds_completed=1,
+        stats=TraversalStats(nodes=5, terminals=1, cutoffs=2, node_limit_cutoffs=0, max_depth_reached=3),
+        advantage_samples=[make_sample(0, 1, 1.0)],
+        strategy_samples=[make_sample(0, 1, 2.0)],
+    )
+    second_result = TraversalWorkerBatchResult(
+        batch_index=0,
+        traverser=1,
+        seeds_completed=2,
+        stats=TraversalStats(nodes=7, terminals=0, cutoffs=0, node_limit_cutoffs=4, max_depth_reached=2),
+        advantage_samples=[make_sample(1, 1, 3.0)],
+        strategy_samples=[make_sample(1, 1, 4.0), make_sample(0, 1, 5.0)],
+    )
+
+    total_stats, traversals = trainer._merge_parallel_traversal_results([first_result, second_result])
+
+    assert traversals == 3
+    assert total_stats.nodes == 12
+    assert total_stats.terminals == 1
+    assert total_stats.cutoffs == 2
+    assert total_stats.node_limit_cutoffs == 4
+    assert total_stats.max_depth_reached == 3
+    assert len(trainer.advantage_memories[0]) == 1
+    assert len(trainer.advantage_memories[1]) == 1
+    assert len(trainer.strategy_memory) == 3
+
+    second_result.advantage_samples[0].target[0] = 99.0
+    assert trainer.advantage_memories[1].samples[0].target[0] == 3.0
 
 
 def test_strategy_net_bot_returns_legal_phase_local_action(tmp_path: Path) -> None:

--- a/src/coolrl/lost_cities/tests/test_deep_cfr_traversal.py
+++ b/src/coolrl/lost_cities/tests/test_deep_cfr_traversal.py
@@ -111,6 +111,33 @@ def test_cfr_traversal_node_limit_cutoff_returns_current_score_diff() -> None:
     assert stats.nodes == 1
 
 
+def test_cfr_traversal_node_limit_is_hard_cap_for_traverser_expansion() -> None:
+    config = tier_config("tier1", seed=27)
+    input_dim = infer_input_dim(config)
+    nets = [
+        AdvantageNet(input_dim, config.action_size, NetworkConfig(hidden_size=16, num_layers=1)),
+        AdvantageNet(input_dim, config.action_size, NetworkConfig(hidden_size=16, num_layers=1)),
+    ]
+    memories = [AdvantageMemory(100), AdvantageMemory(100)]
+
+    value, stats = cfr_traverse(
+        GameState.new_game(config),
+        0,
+        1,
+        nets,
+        memories,
+        StrategyMemory(100),
+        device=torch.device("cpu"),
+        max_depth=None,
+        max_nodes_per_traversal=2,
+        rng=np.random.default_rng(29),
+    )
+
+    assert math.isfinite(value)
+    assert stats.nodes == 2
+    assert stats.node_limit_cutoffs > 0
+
+
 def test_cfr_traversal_stores_regrets_for_multiple_traverser_decisions() -> None:
     config = tier_config("tier1", seed=11)
     input_dim = infer_input_dim(config)

--- a/src/coolrl/lost_cities/tests/test_deep_cfr_traversal.py
+++ b/src/coolrl/lost_cities/tests/test_deep_cfr_traversal.py
@@ -9,7 +9,7 @@ from coolrl.lost_cities.deep_cfr.encoding import infer_input_dim
 from coolrl.lost_cities.deep_cfr.memory import AdvantageMemory, StrategyMemory
 from coolrl.lost_cities.deep_cfr.networks import AdvantageNet, regret_matching
 from coolrl.lost_cities.deep_cfr.config import NetworkConfig
-from coolrl.lost_cities.deep_cfr.traversal import cfr_traverse
+from coolrl.lost_cities.deep_cfr.traversal import TraversalTimingStats, cfr_traverse
 from coolrl.lost_cities.game import Card, GameState, tier_config
 
 
@@ -151,3 +151,70 @@ def test_cfr_traversal_stores_regrets_for_multiple_traverser_decisions() -> None
 
     assert saw_card_phase
     assert saw_draw_phase
+
+
+def test_cfr_traversal_can_skip_opponent_strategy_samples() -> None:
+    config = tier_config("tier1", seed=31)
+    input_dim = infer_input_dim(config)
+    nets = [
+        AdvantageNet(input_dim, config.action_size, NetworkConfig(hidden_size=16, num_layers=1)),
+        AdvantageNet(input_dim, config.action_size, NetworkConfig(hidden_size=16, num_layers=1)),
+    ]
+    memories = [AdvantageMemory(100), AdvantageMemory(100)]
+    strategy_memory = StrategyMemory(100)
+
+    value, stats = cfr_traverse(
+        GameState.new_game(config),
+        0,
+        1,
+        nets,
+        memories,
+        strategy_memory,
+        device=torch.device("cpu"),
+        max_depth=2,
+        max_nodes_per_traversal=100,
+        strategy_sample_interval=1,
+        store_strategy_on_opponent_nodes=False,
+        store_strategy_on_traverser_nodes=True,
+        rng=np.random.default_rng(37),
+    )
+
+    assert math.isfinite(value)
+    assert stats.nodes > 0
+    assert len(strategy_memory) > 0
+    assert all(sample.player == 0 for sample in strategy_memory.samples)
+
+
+def test_cfr_traversal_optional_hotspot_timing_collects_nonnegative_values() -> None:
+    config = tier_config("tier1", seed=41)
+    input_dim = infer_input_dim(config)
+    nets = [
+        AdvantageNet(input_dim, config.action_size, NetworkConfig(hidden_size=16, num_layers=1)),
+        AdvantageNet(input_dim, config.action_size, NetworkConfig(hidden_size=16, num_layers=1)),
+    ]
+    memories = [AdvantageMemory(100), AdvantageMemory(100)]
+    timing_stats = TraversalTimingStats()
+
+    value, stats = cfr_traverse(
+        GameState.new_game(config),
+        0,
+        1,
+        nets,
+        memories,
+        StrategyMemory(100),
+        device=torch.device("cpu"),
+        max_depth=2,
+        max_nodes_per_traversal=100,
+        rng=np.random.default_rng(43),
+        timing_stats=timing_stats,
+    )
+
+    assert math.isfinite(value)
+    assert stats.nodes > 0
+    assert timing_stats.traversal_wall_seconds >= 0.0
+    assert timing_stats.encode_information_state_seconds >= 0.0
+    assert timing_stats.advantage_forward_seconds >= 0.0
+    assert timing_stats.regret_matching_seconds >= 0.0
+    assert timing_stats.clone_apply_seconds >= 0.0
+    assert timing_stats.memory_add_seconds >= 0.0
+    assert timing_stats.policy_calls > 0


### PR DESCRIPTION
Add spawn-safe CPU multiprocessing for traversal generation using frozen advantage-network snapshots, worker-local CPU AdvantageNet reconstruction, and ordered incremental result merging in the trainer while preserving the in-process path for num_workers <= 1.

Add pure-Python traversal performance controls: optional hotspot timing for traversal wall time / encoding / forward / regret matching / clone+apply / memory add, torch.inference_mode() for policy inference, strategy sample-thinning knobs, and worker-side torch thread limiting without changing training thread settings.

Extend reservoir memory merging with extend_samples() driven by the trainer RNG, add checkpoint.save_latest_only for fast experiment loops, and document faster probe/evaluation settings in the Lost Cities Deep CFR YAML profiles.

Validation:

- uv run pytest -q src/coolrl/lost_cities/tests/test_deep_cfr_config.py src/coolrl/lost_cities/tests/test_deep_cfr_encoding.py src/coolrl/lost_cities/tests/test_deep_cfr_traversal.py src/coolrl/lost_cities/tests/test_deep_cfr_smoke.py

- uv run python -m py_compile src/coolrl/lost_cities/deep_cfr/config.py src/coolrl/lost_cities/deep_cfr/traversal.py src/coolrl/lost_cities/deep_cfr/trainer.py src/coolrl/lost_cities/deep_cfr/traversal_worker.py

- tiny CLI smoke with num_workers=2, profile_hotspots=true, progress_every_traversals=0, and save_latest_only=true