### PR TITLE
Add torch dependency to lost-cities and dev extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ lost-cities = [
     "numpy>=1.26.0",
     "pygame-gui>=0.6.14",
     "pyyaml>=6.0.3",
+    "torch>=2.0.0",
 ]
 all = [
     "coolrl[poker,omok,omok-tui,lost-cities]",
@@ -63,6 +64,7 @@ dev = [
     "pygame-gui>=0.6.14",
     "pytest>=9.0.3",
     "pyyaml>=6.0.3",
+    "torch>=2.0.0",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -150,6 +150,7 @@ lost-cities = [
     { name = "numpy" },
     { name = "pygame-gui" },
     { name = "pyyaml" },
+    { name = "torch" },
 ]
 omok = [
     { name = "matplotlib" },
@@ -211,6 +212,7 @@ dev = [
     { name = "pygame-gui" },
     { name = "pytest" },
     { name = "pyyaml" },
+    { name = "torch" },
 ]
 
 [package.metadata]
@@ -241,6 +243,7 @@ requires-dist = [
     { name = "textual", marker = "extra == 'omok-tui'", specifier = ">=0.85.0" },
     { name = "textual", marker = "extra == 'omok-tui-cuda'", specifier = ">=0.85.0" },
     { name = "textual", marker = "extra == 'omok-tui-tensorrt'", specifier = ">=0.85.0" },
+    { name = "torch", marker = "extra == 'lost-cities'", specifier = ">=2.0.0" },
     { name = "torch", marker = "extra == 'omok'", specifier = ">=2.0.0" },
 ]
 provides-extras = ["poker", "omok", "omok-tui", "omok-tui-cuda", "omok-tui-tensorrt", "omok-tensorrt", "lost-cities", "all"]
@@ -252,6 +255,7 @@ dev = [
     { name = "pygame-gui", specifier = ">=0.6.14" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "torch", specifier = ">=2.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Added PyTorch as a dependency to the `lost-cities` and `dev` optional dependency groups in the project configuration.

## Changes
- Added `torch>=2.0.0` to the `lost-cities` extras dependencies
- Added `torch>=2.0.0` to the `dev` extras dependencies

## Details
This change ensures that PyTorch is available when installing the lost-cities game variant or when setting up the development environment. The minimum version constraint of 2.0.0 aligns with the project's requirement for modern PyTorch features.

https://claude.ai/code/session_016sjbCFjaRWMtqPLNGBbp93