### PR TITLE
Add flexible traversal benchmark modes and refactor result logging

### DIFF
--- a/src/coolrl/lost_cities/deep_cfr/benchmark.py
+++ b/src/coolrl/lost_cities/deep_cfr/benchmark.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+import logging
 import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from .config import RunConfig, config_from_dict
 from .trainer import DeepCFRTrainer
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(slots=True)
@@ -70,58 +73,64 @@ def _run_traversal_benchmark_once(config: RunConfig, *, iteration: int) -> Trave
     )
 
 
+def _result_to_dict(r: TraversalBenchmarkResult) -> dict[str, Any]:
+    return {
+        "num_workers": r.num_workers,
+        "traversal_seconds": r.traversal_seconds,
+        "total_nodes": r.total_nodes,
+        "traversals": r.traversals,
+        "nodes_per_second": r.nodes_per_second,
+        "avg_nodes_per_traversal": r.avg_nodes_per_traversal,
+        "cutoffs": r.cutoffs,
+        "cutoff_rate": r.cutoff_rate,
+        "node_limit_cutoffs": r.node_limit_cutoffs,
+        "node_limit_cutoff_rate": r.node_limit_cutoff_rate,
+        "cutoff_rollouts": r.cutoff_rollouts,
+        "cutoff_rollout_steps": r.cutoff_rollout_steps,
+        "cutoff_rollout_max_step_timeouts": r.cutoff_rollout_max_step_timeouts,
+    }
+
+
 def benchmark_traversal_modes(
     config: RunConfig,
     *,
-    mp_workers: int,
+    mp_workers: int = 2,
     iteration: int = 1,
+    mode: Literal["compare", "single", "mp"] = "compare",
 ) -> dict[str, Any]:
-    if mp_workers <= 1:
-        raise ValueError(f"mp_workers must be > 1 for comparison benchmarking, got {mp_workers}")
+    if mode in ("compare", "mp") and mp_workers <= 1:
+        raise ValueError(f"mp_workers must be > 1 for mode={mode!r}, got {mp_workers}")
 
     with tempfile.TemporaryDirectory(prefix="lost_cities_deep_cfr_benchmark_") as temp_dir:
         base_dir = Path(temp_dir)
-        single = _run_traversal_benchmark_once(
-            _benchmark_config_variant(config, num_workers=0, checkpoint_dir=base_dir / "single"),
-            iteration=iteration,
-        )
-        multiprocessing = _run_traversal_benchmark_once(
-            _benchmark_config_variant(config, num_workers=mp_workers, checkpoint_dir=base_dir / "multi"),
-            iteration=iteration,
-        )
 
-    return {
-        "device_used": "cpu",
-        "iteration": iteration,
-        "single_process": {
-            "num_workers": single.num_workers,
-            "traversal_seconds": single.traversal_seconds,
-            "total_nodes": single.total_nodes,
-            "traversals": single.traversals,
-            "nodes_per_second": single.nodes_per_second,
-            "avg_nodes_per_traversal": single.avg_nodes_per_traversal,
-            "cutoffs": single.cutoffs,
-            "cutoff_rate": single.cutoff_rate,
-            "node_limit_cutoffs": single.node_limit_cutoffs,
-            "node_limit_cutoff_rate": single.node_limit_cutoff_rate,
-            "cutoff_rollouts": single.cutoff_rollouts,
-            "cutoff_rollout_steps": single.cutoff_rollout_steps,
-            "cutoff_rollout_max_step_timeouts": single.cutoff_rollout_max_step_timeouts,
-        },
-        "multiprocessing": {
-            "num_workers": multiprocessing.num_workers,
-            "traversal_seconds": multiprocessing.traversal_seconds,
-            "total_nodes": multiprocessing.total_nodes,
-            "traversals": multiprocessing.traversals,
-            "nodes_per_second": multiprocessing.nodes_per_second,
-            "avg_nodes_per_traversal": multiprocessing.avg_nodes_per_traversal,
-            "cutoffs": multiprocessing.cutoffs,
-            "cutoff_rate": multiprocessing.cutoff_rate,
-            "node_limit_cutoffs": multiprocessing.node_limit_cutoffs,
-            "node_limit_cutoff_rate": multiprocessing.node_limit_cutoff_rate,
-            "cutoff_rollouts": multiprocessing.cutoff_rollouts,
-            "cutoff_rollout_steps": multiprocessing.cutoff_rollout_steps,
-            "cutoff_rollout_max_step_timeouts": multiprocessing.cutoff_rollout_max_step_timeouts,
-        },
-        "speedup_vs_single_process": single.traversal_seconds / max(1.0e-9, multiprocessing.traversal_seconds),
-    }
+        single_result: TraversalBenchmarkResult | None = None
+        mp_result: TraversalBenchmarkResult | None = None
+
+        if mode in ("compare", "single"):
+            logger.info("Running single-process traversal benchmark...")
+            single_result = _run_traversal_benchmark_once(
+                _benchmark_config_variant(config, num_workers=0, checkpoint_dir=base_dir / "single"),
+                iteration=iteration,
+            )
+
+        if mode in ("compare", "mp"):
+            logger.info("Running multiprocessing traversal benchmark with workers={}...", mp_workers)
+            mp_result = _run_traversal_benchmark_once(
+                _benchmark_config_variant(config, num_workers=mp_workers, checkpoint_dir=base_dir / "multi"),
+                iteration=iteration,
+            )
+
+    out: dict[str, Any] = {"device_used": "cpu", "iteration": iteration}
+
+    if single_result is not None:
+        out["single_process"] = _result_to_dict(single_result)
+    if mp_result is not None:
+        out["multiprocessing"] = _result_to_dict(mp_result)
+
+    if single_result is not None and mp_result is not None:
+        out["speedup_vs_single_process"] = single_result.traversal_seconds / max(1.0e-9, mp_result.traversal_seconds)
+    else:
+        out["speedup_vs_single_process"] = "n/a"
+
+    return out

--- a/src/coolrl/lost_cities/deep_cfr/cli.py
+++ b/src/coolrl/lost_cities/deep_cfr/cli.py
@@ -75,55 +75,47 @@ def eval_command(args: argparse.Namespace) -> None:
     )
 
 
+def _log_traversal_result(label: str, r: dict) -> None:
+    logger.info(
+        "{}: workers={} traversal_seconds={:.4f} total_nodes={} traversals={} avg_nodes_per_traversal={:.1f} nodes_per_second={:.1f} cutoffs={} cutoff_rate={:.4f} node_limit_cutoffs={} node_limit_cutoff_rate={:.4f} cutoff_rollouts={} rollout_steps={} rollout_timeouts={}",
+        label,
+        r["num_workers"],
+        r["traversal_seconds"],
+        r["total_nodes"],
+        r["traversals"],
+        r["avg_nodes_per_traversal"],
+        r["nodes_per_second"],
+        r["cutoffs"],
+        r["cutoff_rate"],
+        r["node_limit_cutoffs"],
+        r["node_limit_cutoff_rate"],
+        r["cutoff_rollouts"],
+        r["cutoff_rollout_steps"],
+        r["cutoff_rollout_max_step_timeouts"],
+    )
+
+
 def benchmark_traversal_command(args: argparse.Namespace) -> None:
     config = load_config(args.config)
     result = benchmark_traversal_modes(
         config,
         mp_workers=args.mp_workers,
         iteration=args.iteration,
+        mode=args.mode,
     )
-    single = result["single_process"]
-    multiprocessing = result["multiprocessing"]
     logger.info(
         "Traversal benchmark uses device={} for both modes so the comparison reflects traversal multiprocessing overhead/speedup.",
         result["device_used"],
     )
-    logger.info(
-        "Single-process: workers={} traversal_seconds={:.4f} total_nodes={} traversals={} avg_nodes_per_traversal={:.1f} nodes_per_second={:.1f} cutoffs={} cutoff_rate={:.4f} node_limit_cutoffs={} node_limit_cutoff_rate={:.4f} cutoff_rollouts={} rollout_steps={} rollout_timeouts={}",
-        single["num_workers"],
-        single["traversal_seconds"],
-        single["total_nodes"],
-        single["traversals"],
-        single["avg_nodes_per_traversal"],
-        single["nodes_per_second"],
-        single["cutoffs"],
-        single["cutoff_rate"],
-        single["node_limit_cutoffs"],
-        single["node_limit_cutoff_rate"],
-        single["cutoff_rollouts"],
-        single["cutoff_rollout_steps"],
-        single["cutoff_rollout_max_step_timeouts"],
-    )
-    logger.info(
-        "Multiprocessing: workers={} traversal_seconds={:.4f} total_nodes={} traversals={} avg_nodes_per_traversal={:.1f} nodes_per_second={:.1f} cutoffs={} cutoff_rate={:.4f} node_limit_cutoffs={} node_limit_cutoff_rate={:.4f} cutoff_rollouts={} rollout_steps={} rollout_timeouts={}",
-        multiprocessing["num_workers"],
-        multiprocessing["traversal_seconds"],
-        multiprocessing["total_nodes"],
-        multiprocessing["traversals"],
-        multiprocessing["avg_nodes_per_traversal"],
-        multiprocessing["nodes_per_second"],
-        multiprocessing["cutoffs"],
-        multiprocessing["cutoff_rate"],
-        multiprocessing["node_limit_cutoffs"],
-        multiprocessing["node_limit_cutoff_rate"],
-        multiprocessing["cutoff_rollouts"],
-        multiprocessing["cutoff_rollout_steps"],
-        multiprocessing["cutoff_rollout_max_step_timeouts"],
-    )
-    logger.info(
-        "Traversal benchmark speedup vs single-process: {:.3f}x",
-        result["speedup_vs_single_process"],
-    )
+    if "single_process" in result:
+        _log_traversal_result("Single-process", result["single_process"])
+    if "multiprocessing" in result:
+        _log_traversal_result("Multiprocessing", result["multiprocessing"])
+    speedup = result["speedup_vs_single_process"]
+    if speedup == "n/a":
+        logger.info("Traversal benchmark speedup vs single-process: n/a")
+    else:
+        logger.info("Traversal benchmark speedup vs single-process: {:.3f}x", speedup)
 
 
 def status_command(args: argparse.Namespace) -> None:
@@ -216,6 +208,7 @@ def build_parser() -> argparse.ArgumentParser:
     benchmark.add_argument("--config", type=Path, default=Path("configs/lost_cities_deep_cfr_probe.yaml"))
     benchmark.add_argument("--mp-workers", type=int, default=2)
     benchmark.add_argument("--iteration", type=int, default=1)
+    benchmark.add_argument("--mode", choices=["compare", "single", "mp"], default="compare")
     benchmark.set_defaults(func=benchmark_traversal_command)
 
     status = subparsers.add_parser("status")

--- a/src/coolrl/lost_cities/tests/test_deep_cfr_smoke.py
+++ b/src/coolrl/lost_cities/tests/test_deep_cfr_smoke.py
@@ -159,8 +159,8 @@ def test_tiny_training_run_profiles_hotspots_and_can_save_latest_only(tmp_path: 
     assert progress["traversal_profile_memory_add_seconds"] >= 0.0
 
 
-def test_traversal_benchmark_compares_single_and_multiprocessing(tmp_path: Path) -> None:
-    cfg = config_from_dict(
+def _minimal_benchmark_cfg(tmp_path: Path):
+    return config_from_dict(
         {
             "max_iterations": 0,
             "device": "cpu",
@@ -181,14 +181,42 @@ def test_traversal_benchmark_compares_single_and_multiprocessing(tmp_path: Path)
         }
     )
 
-    result = benchmark_traversal_modes(cfg, mp_workers=2, iteration=1)
+
+def test_traversal_benchmark_compares_single_and_multiprocessing(tmp_path: Path) -> None:
+    cfg = _minimal_benchmark_cfg(tmp_path)
+    result = benchmark_traversal_modes(cfg, mp_workers=2, iteration=1, mode="compare")
 
     assert result["device_used"] == "cpu"
     assert result["single_process"]["num_workers"] == 0
     assert result["multiprocessing"]["num_workers"] == 2
     assert result["single_process"]["traversal_seconds"] >= 0.0
     assert result["multiprocessing"]["traversal_seconds"] >= 0.0
+    assert isinstance(result["speedup_vs_single_process"], float)
     assert result["speedup_vs_single_process"] >= 0.0
+
+
+def test_traversal_benchmark_single_mode(tmp_path: Path) -> None:
+    cfg = _minimal_benchmark_cfg(tmp_path)
+    result = benchmark_traversal_modes(cfg, iteration=1, mode="single")
+
+    assert result["device_used"] == "cpu"
+    assert "single_process" in result
+    assert "multiprocessing" not in result
+    assert result["single_process"]["num_workers"] == 0
+    assert result["single_process"]["traversal_seconds"] >= 0.0
+    assert result["speedup_vs_single_process"] == "n/a"
+
+
+def test_traversal_benchmark_mp_mode(tmp_path: Path) -> None:
+    cfg = _minimal_benchmark_cfg(tmp_path)
+    result = benchmark_traversal_modes(cfg, mp_workers=2, iteration=1, mode="mp")
+
+    assert result["device_used"] == "cpu"
+    assert "multiprocessing" in result
+    assert "single_process" not in result
+    assert result["multiprocessing"]["num_workers"] == 2
+    assert result["multiprocessing"]["traversal_seconds"] >= 0.0
+    assert result["speedup_vs_single_process"] == "n/a"
 
 
 def test_parallel_traversal_result_merge_aggregates_stats(tmp_path: Path) -> None:


### PR DESCRIPTION
## 요약

Traversal 벤치마킹 기능을 리팩터링해서, 벤치마크 실행 모드를 더 유연하게 선택할 수 있도록 했습니다. 이제 단일 프로세스만 실행하거나, 멀티프로세싱만 실행하거나, 둘을 비교 실행할 수 있습니다. 또한 결과 로깅 코드의 중복을 줄였습니다.

## 주요 변경 사항

* `benchmark_traversal_modes()`에 `mode` 파라미터를 추가했습니다. 선택지는 세 가지입니다.

  * `"compare"` 기본값: 단일 프로세스 벤치마크와 멀티프로세싱 벤치마크를 모두 실행
  * `"single"`: 단일 프로세스 벤치마크만 실행
  * `"mp"`: 멀티프로세싱 벤치마크만 실행

* `TraversalBenchmarkResult` 객체를 딕셔너리로 변환하는 중복 로직을 제거하기 위해 `_result_to_dict()` 헬퍼 함수를 분리했습니다.

* CLI 쪽의 반복적인 로깅 코드를 줄이고 유지보수성을 높이기 위해 `_log_traversal_result()` 헬퍼 함수를 분리했습니다.

* `benchmark_traversal_modes()`에서 `mp_workers` 파라미터를 선택적으로 바꾸고, 기본값을 `2`로 설정했습니다.

* 멀티프로세싱을 실제로 사용하는 모드인 `"compare"` 또는 `"mp"`에서만 `mp_workers > 1`을 요구하도록 검증 로직을 수정했습니다.

* speedup 계산을 조건부로 바꿨습니다. 두 벤치마크가 모두 실행되지 않은 경우에는 speedup을 계산하지 않고 `"n/a"`를 반환합니다.

* 커맨드라인에서 벤치마크 모드를 선택할 수 있도록 `--mode` CLI 인자를 추가했습니다.

* 세 가지 벤치마크 모드 각각에 대해 전용 테스트 함수를 추가해 테스트 커버리지를 보강했습니다.

## 구현 세부 사항

* 기본 모드를 `"compare"`로 유지해 기존 동작과의 하위 호환성을 보존했습니다.

* 출력 결과 딕셔너리에는 실제로 실행된 벤치마크 결과만 조건부로 포함되도록 했습니다.

* speedup을 계산할 수 없는 경우에도 로깅이 자연스럽게 처리되도록 했습니다.

* 이번 변경은 기존 벤치마크 기능을 그대로 유지하면서, 다양한 사용 상황에 맞게 더 유연하게 실행할 수 있도록 확장한 것입니다.
