### PR TITLE
fix(deep-cfr): 멀티프로세싱 벤치마크 로깅 포맷 오류 수정

### DIFF
--- a/src/coolrl/lost_cities/deep_cfr/benchmark.py
+++ b/src/coolrl/lost_cities/deep_cfr/benchmark.py
@@ -115,7 +115,7 @@ def benchmark_traversal_modes(
             )
 
         if mode in ("compare", "mp"):
-            logger.info("Running multiprocessing traversal benchmark with workers={}...", mp_workers)
+            logger.info("Running multiprocessing traversal benchmark with requested_workers=%s...", mp_workers)
             mp_result = _run_traversal_benchmark_once(
                 _benchmark_config_variant(config, num_workers=mp_workers, checkpoint_dir=base_dir / "multi"),
                 iteration=iteration,

--- a/src/coolrl/lost_cities/deep_cfr/trainer.py
+++ b/src/coolrl/lost_cities/deep_cfr/trainer.py
@@ -396,7 +396,8 @@ class DeepCFRTrainer:
 
         max_workers = min(self.num_workers, len(batches))
         logger.info(
-            "Traversal multiprocessing enabled: num_workers={} batches={} chunk_size={}",
+            "Traversal multiprocessing enabled: requested_workers={} effective_workers={} batches={} chunk_size={}",
+            self.num_workers,
             max_workers,
             len(batches),
             self.traversal_worker_chunk_size,

--- a/src/coolrl/lost_cities/tests/test_deep_cfr_smoke.py
+++ b/src/coolrl/lost_cities/tests/test_deep_cfr_smoke.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 import numpy as np
 import torch
 
+import coolrl.lost_cities.deep_cfr.benchmark as benchmark_module
 from coolrl.lost_cities.deep_cfr.benchmark import benchmark_traversal_modes
 from coolrl.lost_cities.deep_cfr.config import config_from_dict
 from coolrl.lost_cities.deep_cfr.encoding import infer_input_dim
@@ -217,6 +219,44 @@ def test_traversal_benchmark_mp_mode(tmp_path: Path) -> None:
     assert result["multiprocessing"]["num_workers"] == 2
     assert result["multiprocessing"]["traversal_seconds"] >= 0.0
     assert result["speedup_vs_single_process"] == "n/a"
+
+
+def test_traversal_benchmark_mp_mode_does_not_emit_logging_error(
+    tmp_path: Path,
+    monkeypatch,
+    caplog,
+    capsys,
+) -> None:
+    cfg = _minimal_benchmark_cfg(tmp_path)
+
+    def _fake_run_traversal_benchmark_once(*_args, **_kwargs) -> benchmark_module.TraversalBenchmarkResult:
+        return benchmark_module.TraversalBenchmarkResult(
+            num_workers=2,
+            traversal_seconds=0.01,
+            total_nodes=10,
+            traversals=2,
+            nodes_per_second=1000.0,
+            avg_nodes_per_traversal=5.0,
+            cutoffs=0,
+            cutoff_rate=0.0,
+            node_limit_cutoffs=0,
+            node_limit_cutoff_rate=0.0,
+            cutoff_rollouts=0,
+            cutoff_rollout_steps=0,
+            cutoff_rollout_max_step_timeouts=0,
+        )
+
+    monkeypatch.setattr(
+        benchmark_module,
+        "_run_traversal_benchmark_once",
+        _fake_run_traversal_benchmark_once,
+    )
+
+    with caplog.at_level(logging.INFO, logger=benchmark_module.__name__):
+        benchmark_traversal_modes(cfg, mp_workers=2, iteration=1, mode="mp")
+
+    assert "requested_workers=2" in caplog.text
+    assert "--- Logging error ---" not in capsys.readouterr().err
 
 
 def test_parallel_traversal_result_merge_aggregates_stats(tmp_path: Path) -> None:


### PR DESCRIPTION
## 요약
- benchmark.py stdlib logging 포맷 오류 수정 (%s 사용)
- trainer.py에서 requested/effective worker를 분리 로깅
- mp 벤치마크 경로 로깅 오류 회귀 테스트 추가

## 검증
- uv run pytest src/coolrl/lost_cities/tests/test_deep_cfr_smoke.py -k "traversal_benchmark_mp_mode"
- uv run pytest src/coolrl/lost_cities/tests/test_deep_cfr_smoke.py -k "tiny_training_run_completes_with_parallel_traversal"
- 수동 재현 커맨드에서 '--- Logging error ---' 미발생 확인
- 요청 12 / 유효 10 워커 로그 확인

Closes #22