### PR TITLE
feat(deep-cfr): traversal 유효 워커 수 명확화 및 worker cap 경고 추가

### DIFF
--- a/docs/lost-cities-deep-cfr-training-notes.md
+++ b/docs/lost-cities-deep-cfr-training-notes.md
@@ -240,6 +240,35 @@ uv run python -m coolrl.lost_cities.deep_cfr.cli benchmark-traversal \
 - `safe_heuristic` 상대로 `avg_diff` 또는 `win_rate`가 개선됨
 - GUI trace에서 expedition을 열고 확장하는 행동이 보임
 
+## Traversal Worker 튜닝 노트
+
+Deep CFR traversal multiprocessing에서 실제 executor worker 수는 요청한 worker 수와 다를 수 있습니다.
+
+- `requested_workers`: 설정/CLI에서 요청한 worker 수
+- `effective_workers`: 실제 사용된 worker 수
+- `effective_workers = min(requested_workers, num_batches)`
+
+`num_batches`는 아래 값으로 결정됩니다.
+
+```text
+num_batches = 2 players * ceil(traversals_per_player / traversal_worker_chunk_size)
+```
+
+예시:
+
+```yaml
+traversals_per_player: 20
+traversal_worker_chunk_size: 4
+num_workers: 12
+```
+
+위 설정의 배치 수는 `2 * ceil(20 / 4) = 10`이므로 실제 worker는 최대 10입니다.
+
+worker를 더 사용하고 싶다면:
+
+- `traversal_worker_chunk_size`를 줄여 배치 수를 늘리거나
+- `traversals_per_player`를 늘려 배치 수를 늘립니다.
+
 ## Commands
 
 Status:

--- a/src/coolrl/lost_cities/deep_cfr/benchmark.py
+++ b/src/coolrl/lost_cities/deep_cfr/benchmark.py
@@ -16,6 +16,9 @@ logger = logging.getLogger(__name__)
 @dataclass(slots=True)
 class TraversalBenchmarkResult:
     num_workers: int
+    requested_workers: int
+    effective_workers: int
+    num_batches: int
     traversal_seconds: float
     total_nodes: int
     traversals: int
@@ -50,14 +53,26 @@ def _benchmark_config_variant(config: RunConfig, *, num_workers: int, checkpoint
 
 def _run_traversal_benchmark_once(config: RunConfig, *, iteration: int) -> TraversalBenchmarkResult:
     trainer = DeepCFRTrainer(config)
+    requested_workers = trainer.num_workers
+    effective_workers = requested_workers
+    num_batches = 0
+    if requested_workers > 1:
+        advantage_net_state_dicts = trainer._frozen_advantage_state_dicts()
+        batches = trainer._build_traversal_worker_batches(iteration, advantage_net_state_dicts)
+        num_batches = len(batches)
+        effective_workers = min(requested_workers, num_batches)
+
     started = time.monotonic()
-    if trainer.num_workers <= 1:
+    if requested_workers <= 1:
         total_stats, traversals, _ = trainer._run_traversals_single_process(iteration)
     else:
         total_stats, traversals, _ = trainer._run_traversals_parallel(iteration)
     traversal_seconds = time.monotonic() - started
     return TraversalBenchmarkResult(
-        num_workers=trainer.num_workers,
+        num_workers=requested_workers,
+        requested_workers=requested_workers,
+        effective_workers=effective_workers,
+        num_batches=num_batches,
         traversal_seconds=traversal_seconds,
         total_nodes=total_stats.nodes,
         traversals=traversals,
@@ -76,6 +91,9 @@ def _run_traversal_benchmark_once(config: RunConfig, *, iteration: int) -> Trave
 def _result_to_dict(r: TraversalBenchmarkResult) -> dict[str, Any]:
     return {
         "num_workers": r.num_workers,
+        "requested_workers": r.requested_workers,
+        "effective_workers": r.effective_workers,
+        "num_batches": r.num_batches,
         "traversal_seconds": r.traversal_seconds,
         "total_nodes": r.total_nodes,
         "traversals": r.traversals,

--- a/src/coolrl/lost_cities/deep_cfr/benchmark.py
+++ b/src/coolrl/lost_cities/deep_cfr/benchmark.py
@@ -57,9 +57,7 @@ def _run_traversal_benchmark_once(config: RunConfig, *, iteration: int) -> Trave
     effective_workers = requested_workers
     num_batches = 0
     if requested_workers > 1:
-        advantage_net_state_dicts = trainer._frozen_advantage_state_dicts()
-        batches = trainer._build_traversal_worker_batches(iteration, advantage_net_state_dicts)
-        num_batches = len(batches)
+        num_batches = trainer._estimated_traversal_batch_count()
         effective_workers = min(requested_workers, num_batches)
 
     started = time.monotonic()

--- a/src/coolrl/lost_cities/deep_cfr/cli.py
+++ b/src/coolrl/lost_cities/deep_cfr/cli.py
@@ -76,10 +76,15 @@ def eval_command(args: argparse.Namespace) -> None:
 
 
 def _log_traversal_result(label: str, r: dict) -> None:
+    requested_workers = r.get("requested_workers", r["num_workers"])
+    effective_workers = r.get("effective_workers", r["num_workers"])
+    num_batches = r.get("num_batches", "n/a")
     logger.info(
-        "{}: workers={} traversal_seconds={:.4f} total_nodes={} traversals={} avg_nodes_per_traversal={:.1f} nodes_per_second={:.1f} cutoffs={} cutoff_rate={:.4f} node_limit_cutoffs={} node_limit_cutoff_rate={:.4f} cutoff_rollouts={} rollout_steps={} rollout_timeouts={}",
+        "{}: requested_workers={} effective_workers={} batches={} traversal_seconds={:.4f} total_nodes={} traversals={} avg_nodes_per_traversal={:.1f} nodes_per_second={:.1f} cutoffs={} cutoff_rate={:.4f} node_limit_cutoffs={} node_limit_cutoff_rate={:.4f} cutoff_rollouts={} rollout_steps={} rollout_timeouts={}",
         label,
-        r["num_workers"],
+        requested_workers,
+        effective_workers,
+        num_batches,
         r["traversal_seconds"],
         r["total_nodes"],
         r["traversals"],

--- a/src/coolrl/lost_cities/deep_cfr/trainer.py
+++ b/src/coolrl/lost_cities/deep_cfr/trainer.py
@@ -402,6 +402,13 @@ class DeepCFRTrainer:
             len(batches),
             self.traversal_worker_chunk_size,
         )
+        if max_workers < self.num_workers:
+            logger.warning(
+                "Requested {} traversal workers but only {} batches are available; using {} workers. To use more workers, decrease traversal_worker_chunk_size or increase traversals_per_player.",
+                self.num_workers,
+                len(batches),
+                max_workers,
+            )
 
         total_stats = TraversalStats()
         traversals = 0

--- a/src/coolrl/lost_cities/deep_cfr/trainer.py
+++ b/src/coolrl/lost_cities/deep_cfr/trainer.py
@@ -315,6 +315,13 @@ class DeepCFRTrainer:
             )
         return frozen_state_dicts
 
+    def _estimated_traversal_batch_count(self) -> int:
+        traversals_per_player = int(self.config.traversal.traversals_per_player)
+        if traversals_per_player <= 0:
+            return 0
+        chunks_per_player = (traversals_per_player + self.traversal_worker_chunk_size - 1) // self.traversal_worker_chunk_size
+        return 2 * chunks_per_player
+
     def _build_traversal_worker_batches(
         self,
         iteration: int,
@@ -436,7 +443,7 @@ class DeepCFRTrainer:
                     avg_nodes = progress_nodes / max(1, progress_traversals)
                     nodes_per_second = progress_nodes / max(1.0e-9, elapsed)
                     logger.info(
-                        "Traversal multiprocessing progress: num_workers={} completed_batches={}/{} elapsed_seconds={:.2f} total_nodes={} avg_nodes_per_traversal={:.1f} nodes_per_second={:.1f}",
+                        "Traversal multiprocessing progress: effective_workers={} completed_batches={}/{} elapsed_seconds={:.2f} total_nodes={} avg_nodes_per_traversal={:.1f} nodes_per_second={:.1f}",
                         max_workers,
                         completed_batches,
                         total_batches,

--- a/src/coolrl/lost_cities/tests/test_deep_cfr_smoke.py
+++ b/src/coolrl/lost_cities/tests/test_deep_cfr_smoke.py
@@ -8,6 +8,7 @@ import numpy as np
 import torch
 
 import coolrl.lost_cities.deep_cfr.benchmark as benchmark_module
+import coolrl.lost_cities.deep_cfr.trainer as trainer_module
 from coolrl.lost_cities.deep_cfr.benchmark import benchmark_traversal_modes
 from coolrl.lost_cities.deep_cfr.config import config_from_dict
 from coolrl.lost_cities.deep_cfr.encoding import infer_input_dim
@@ -221,6 +222,35 @@ def test_traversal_benchmark_mp_mode(tmp_path: Path) -> None:
     assert result["speedup_vs_single_process"] == "n/a"
 
 
+def test_traversal_benchmark_mp_mode_reports_requested_and_effective_workers(tmp_path: Path) -> None:
+    cfg = config_from_dict(
+        {
+            "max_iterations": 0,
+            "device": "cpu",
+            "network": {"hidden_size": 16, "num_layers": 1},
+            "traversal": {
+                "traversals_per_player": 20,
+                "max_depth": 2,
+                "max_nodes_per_traversal": 32,
+                "num_workers": 12,
+                "traversal_worker_chunk_size": 4,
+                "progress_every_traversals": 0,
+            },
+            "optimization": {
+                "advantage_updates_per_iteration": 0,
+                "strategy_updates_per_iteration": 0,
+            },
+            "evaluation": {"eval_every": 0, "games": 1},
+            "checkpoint": {"directory": str(tmp_path)},
+        }
+    )
+    result = benchmark_traversal_modes(cfg, mp_workers=12, iteration=1, mode="mp")
+
+    assert result["multiprocessing"]["requested_workers"] == 12
+    assert result["multiprocessing"]["effective_workers"] == 10
+    assert result["multiprocessing"]["num_batches"] == 10
+
+
 def test_traversal_benchmark_mp_mode_does_not_emit_logging_error(
     tmp_path: Path,
     monkeypatch,
@@ -232,6 +262,9 @@ def test_traversal_benchmark_mp_mode_does_not_emit_logging_error(
     def _fake_run_traversal_benchmark_once(*_args, **_kwargs) -> benchmark_module.TraversalBenchmarkResult:
         return benchmark_module.TraversalBenchmarkResult(
             num_workers=2,
+            requested_workers=2,
+            effective_workers=2,
+            num_batches=2,
             traversal_seconds=0.01,
             total_nodes=10,
             traversals=2,
@@ -257,6 +290,79 @@ def test_traversal_benchmark_mp_mode_does_not_emit_logging_error(
 
     assert "requested_workers=2" in caplog.text
     assert "--- Logging error ---" not in capsys.readouterr().err
+
+
+def test_parallel_traversal_logs_warning_when_requested_workers_exceed_batches(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    cfg = config_from_dict(
+        {
+            "max_iterations": 0,
+            "device": "cpu",
+            "network": {"hidden_size": 16, "num_layers": 1},
+            "traversal": {
+                "traversals_per_player": 1,
+                "max_depth": 2,
+                "num_workers": 12,
+                "traversal_worker_chunk_size": 4,
+                "progress_every_traversals": 0,
+            },
+            "optimization": {
+                "advantage_updates_per_iteration": 0,
+                "strategy_updates_per_iteration": 0,
+            },
+            "evaluation": {"eval_every": 0, "games": 1},
+            "checkpoint": {"directory": str(tmp_path)},
+        }
+    )
+    trainer = DeepCFRTrainer(cfg)
+
+    warnings: list[str] = []
+
+    def _capture_warning(message: str, *args) -> None:
+        warnings.append(message.format(*args))
+
+    class _FakeFuture:
+        def __init__(self, result: TraversalWorkerBatchResult) -> None:
+            self._result = result
+
+        def result(self) -> TraversalWorkerBatchResult:
+            return self._result
+
+    class _FakeExecutor:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def submit(self, _func, batch):
+            return _FakeFuture(
+                TraversalWorkerBatchResult(
+                    batch_index=batch.batch_index,
+                    traverser=batch.traverser,
+                    seeds_completed=len(batch.seeds),
+                    stats=TraversalStats(nodes=1),
+                    advantage_samples=[],
+                    strategy_samples=[],
+                )
+            )
+
+    monkeypatch.setattr(trainer_module.logger, "warning", _capture_warning)
+    monkeypatch.setattr(trainer_module, "ProcessPoolExecutor", _FakeExecutor)
+    monkeypatch.setattr(trainer_module, "as_completed", lambda futures: futures)
+
+    _, traversals, _ = trainer._run_traversals_parallel(iteration=1)
+
+    assert traversals == 2
+    assert any(
+        "Requested 12 traversal workers but only 2 batches are available; using 2 workers." in warning
+        for warning in warnings
+    )
 
 
 def test_parallel_traversal_result_merge_aggregates_stats(tmp_path: Path) -> None:

--- a/src/coolrl/lost_cities/tests/test_deep_cfr_smoke.py
+++ b/src/coolrl/lost_cities/tests/test_deep_cfr_smoke.py
@@ -292,6 +292,36 @@ def test_traversal_benchmark_mp_mode_does_not_emit_logging_error(
     assert "--- Logging error ---" not in capsys.readouterr().err
 
 
+def test_traversal_benchmark_mp_mode_uses_lightweight_batch_count(monkeypatch) -> None:
+    class _FakeTrainer:
+        def __init__(self, _config) -> None:
+            self.num_workers = 12
+
+        def _estimated_traversal_batch_count(self) -> int:
+            return 10
+
+        def _frozen_advantage_state_dicts(self):
+            raise AssertionError("_frozen_advantage_state_dicts should not be called in benchmark metadata path")
+
+        def _build_traversal_worker_batches(self, _iteration, _advantage_net_state_dicts):
+            raise AssertionError("_build_traversal_worker_batches should not be called in benchmark metadata path")
+
+        def _run_traversals_parallel(self, _iteration):
+            return TraversalStats(nodes=20), 4, None
+
+        def _run_traversals_single_process(self, _iteration):
+            raise AssertionError("single-process path should not be used")
+
+    monkeypatch.setattr(benchmark_module, "DeepCFRTrainer", _FakeTrainer)
+    cfg = config_from_dict({"device": "cpu"})
+    result = benchmark_module._run_traversal_benchmark_once(cfg, iteration=1)
+
+    assert result.requested_workers == 12
+    assert result.effective_workers == 10
+    assert result.num_batches == 10
+    assert result.traversals == 4
+
+
 def test_parallel_traversal_logs_warning_when_requested_workers_exceed_batches(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## 요약
- traversal 병렬 실행 로그에서 요청 워커 수와 실제 유효 워커 수를 명확히 구분
- 요청 워커 수가 배치 수에 의해 제한될 때 warning 로그 추가
- benchmark 결과와 CLI 출력에 requested/effective/batches를 함께 노출
- worker 튜닝 가이드를 학습 노트 문서에 추가

## 상세 변경
- trainer.py
  - effective_workers < requested_workers일 때 cap warning 출력
- benchmark.py
  - TraversalBenchmarkResult에 requested_workers, effective_workers, num_batches 추가
  - benchmark 결과 dict에 동일 필드 노출
- cli.py
  - benchmark 출력을 requested_workers/effective_workers/batches 중심으로 표시
- test_deep_cfr_smoke.py
  - mode=mp 결과 필드 확장 검증 테스트 추가
  - worker cap warning 검증 테스트 추가
- docs/lost-cities-deep-cfr-training-notes.md
  - worker 튜닝/배치 계산식 문서화

## 검증
- uv run pytest src/coolrl/lost_cities/tests/test_deep_cfr_smoke.py -k "traversal_benchmark_mp_mode or requested_and_effective_workers or logs_warning_when_requested_workers_exceed_batches"

Closes #23