### PR TITLE
AGENTS.md·CLAUDE.md 저장소 언어 정책 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+## Repository language policy
+
+This repository uses Korean as the default language for project communication.
+
+Required:
+- Commit messages must be written in Korean.
+- PR titles and PR descriptions must be written in Korean.
+- GitHub issue comments and review comments must be written in Korean.
+- Documentation changes must be written in Korean unless the document is intentionally maintained in English.
+- Changelog and release notes must be written in Korean.
+
+Exceptions:
+- Code identifiers, filenames, package names, command names, CLI flags, config keys, protocol fields, and public API names should remain in English.
+- Do not translate quoted external errors, log messages, dependency names, or upstream API names.
+- Preserve the language of existing English documentation unless the task explicitly asks to translate it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+## Repository language policy
+
+Follow `AGENTS.md` as the canonical repository instruction source.
+
+This repository uses Korean as the default language for project communication.
+
+Required:
+- Commit messages must be written in Korean.
+- PR titles and PR descriptions must be written in Korean.
+- GitHub issue comments and review comments must be written in Korean.
+- Documentation changes must be written in Korean unless the document is intentionally maintained in English.
+- Changelog and release notes must be written in Korean.
+
+Exceptions:
+- Code identifiers, filenames, package names, command names, CLI flags, config keys, protocol fields, and public API names should remain in English.
+- Do not translate quoted external errors, log messages, dependency names, or upstream API names.
+- Preserve the language of existing English documentation unless the task explicitly asks to translate it.


### PR DESCRIPTION
### Motivation
- Unify repository-level language guidance so different agents (Codex and Claude Code) follow the same rules for commit messages, PRs, issues, reviews, and docs.
- Make `AGENTS.md` the canonical instruction source and ensure `CLAUDE.md` references it while also including core policy text to avoid missed references.

### Description
- Added `AGENTS.md` at the repo root that declares Korean as the default project communication language and lists required items and exceptions. 
- Added `CLAUDE.md` at the repo root that points to `AGENTS.md` as canonical and also includes the same required items and exceptions inline. 
- Policy text covers required fields (commit messages, PR titles/descriptions, issue/review comments, documentation, changelogs) and explicit exceptions (identifiers, filenames, API names, quoted external errors, and existing English docs).

### Testing
- Validated that both files were created and contain the expected policy by inspecting their contents with `nl -ba AGENTS.md` and `nl -ba CLAUDE.md`, and those commands completed successfully.
- No source code or unit tests were changed, so no test-suite changes were required or run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec54b3198c83248bfae6d975148c38)