### PR TITLE
[codex] Deep CFR auto worker 기본값을 CPU 친화적으로 조정

### DIFF
--- a/src/coolrl/lost_cities/deep_cfr/config.py
+++ b/src/coolrl/lost_cities/deep_cfr/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from dataclasses import asdict, dataclass, field, fields
 from pathlib import Path
 from typing import Any
@@ -80,17 +81,48 @@ class TraversalConfig:
         if self.cutoff_rollout_max_steps <= 0:
             raise ValueError("traversal.cutoff_rollout_max_steps must be positive")
 
+    def _cpu_worker_guess(self) -> int:
+        logical = max(1, os.cpu_count() or 1)
+        physical = None
+        try:
+            psutil = sys.modules.get("psutil")
+            if psutil is None:
+                import psutil as imported_psutil
+
+                psutil = imported_psutil
+            physical = psutil.cpu_count(logical=False)
+        except Exception:
+            physical = None
+        return max(1, int(physical) if physical else logical // 2)
+
+    def estimated_num_batches(self) -> int:
+        traversals_per_player = max(0, int(self.traversals_per_player))
+        if traversals_per_player <= 0:
+            return 0
+        chunk_size = max(1, int(self.traversal_worker_chunk_size))
+        chunks_per_player = (traversals_per_player + chunk_size - 1) // chunk_size
+        return 2 * chunks_per_player
+
     def resolved_num_workers(self) -> tuple[int, bool]:
         value = self.num_workers
         if isinstance(value, str):
             token = value.strip().lower()
             if token == "auto":
-                return max(1, os.cpu_count() or 1), True
+                return self._cpu_worker_guess(), True
             try:
                 return max(0, int(token)), False
             except ValueError as exc:
                 raise ValueError(f"unsupported traversal.num_workers: {value!r}") from exc
         return max(0, int(value)), False
+
+    def resolved_num_workers_for_traversal(self) -> tuple[int, bool, int | None, int | None]:
+        requested_workers, is_auto = self.resolved_num_workers()
+        if not is_auto:
+            return requested_workers, False, None, None
+        cpu_guess = requested_workers
+        num_batches = self.estimated_num_batches()
+        resolved = max(1, min(cpu_guess, num_batches)) if num_batches > 0 else 1
+        return resolved, True, cpu_guess, num_batches
 
 
 @dataclass(slots=True)

--- a/src/coolrl/lost_cities/deep_cfr/trainer.py
+++ b/src/coolrl/lost_cities/deep_cfr/trainer.py
@@ -83,9 +83,18 @@ class DeepCFRTrainer:
         self.checkpoint_dir.mkdir(parents=True, exist_ok=True)
         self.metrics_path = self.checkpoint_dir / "metrics.jsonl"
         self.progress_path = self.checkpoint_dir / "runtime_progress.json"
-        self.num_workers, _ = config.traversal.resolved_num_workers()
+        self.num_workers, num_workers_auto, cpu_guess, num_batches = (
+            config.traversal.resolved_num_workers_for_traversal()
+        )
         self.traversal_worker_chunk_size = max(1, int(config.traversal.traversal_worker_chunk_size))
         self.profile_hotspots = bool(config.traversal.profile_hotspots)
+        if num_workers_auto:
+            logger.info(
+                "Resolved traversal.num_workers=auto to requested_workers={} using cpu_guess={} num_batches={}",
+                self.num_workers,
+                cpu_guess,
+                num_batches,
+            )
         if resume_path is None and self.metrics_path.exists():
             archive = self.metrics_path.with_name(f"metrics.{time.strftime('%Y%m%d-%H%M%S')}.jsonl")
             shutil.move(self.metrics_path, archive)
@@ -316,11 +325,7 @@ class DeepCFRTrainer:
         return frozen_state_dicts
 
     def _estimated_traversal_batch_count(self) -> int:
-        traversals_per_player = int(self.config.traversal.traversals_per_player)
-        if traversals_per_player <= 0:
-            return 0
-        chunks_per_player = (traversals_per_player + self.traversal_worker_chunk_size - 1) // self.traversal_worker_chunk_size
-        return 2 * chunks_per_player
+        return self.config.traversal.estimated_num_batches()
 
     def _build_traversal_worker_batches(
         self,

--- a/src/coolrl/lost_cities/tests/test_deep_cfr_config.py
+++ b/src/coolrl/lost_cities/tests/test_deep_cfr_config.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+import types
 from pathlib import Path
 
 from coolrl.lost_cities.deep_cfr.config import RulesConfig, config_from_dict, load_config
@@ -76,3 +78,114 @@ def test_rules_config_overrides() -> None:
     lc_cfg = RulesConfig(bonus_threshold=7, expedition_penalty=-15).to_lost_cities_config()
     assert lc_cfg.bonus_threshold == 7
     assert lc_cfg.expedition_penalty == -15
+
+
+def test_traversal_num_workers_explicit_values_remain_unchanged() -> None:
+    cfg = config_from_dict(
+        {
+            "traversal": {
+                "num_workers": 4,
+                "traversals_per_player": 20,
+                "traversal_worker_chunk_size": 4,
+            }
+        }
+    )
+
+    resolved, is_auto, cpu_guess, num_batches = cfg.traversal.resolved_num_workers_for_traversal()
+
+    assert resolved == 4
+    assert is_auto is False
+    assert cpu_guess is None
+    assert num_batches is None
+
+
+def test_traversal_num_workers_auto_is_capped_by_batch_count(monkeypatch) -> None:
+    monkeypatch.setattr("coolrl.lost_cities.deep_cfr.config.os.cpu_count", lambda: 32)
+    monkeypatch.setitem(sys.modules, "psutil", types.SimpleNamespace(cpu_count=lambda logical=False: 16))
+    cfg = config_from_dict(
+        {
+            "traversal": {
+                "num_workers": "auto",
+                "traversals_per_player": 3,
+                "traversal_worker_chunk_size": 2,
+            }
+        }
+    )
+
+    resolved, is_auto, cpu_guess, num_batches = cfg.traversal.resolved_num_workers_for_traversal()
+
+    assert resolved == 4
+    assert is_auto is True
+    assert cpu_guess == 16
+    assert num_batches == 4
+
+
+def test_traversal_num_workers_auto_never_returns_below_one(monkeypatch) -> None:
+    monkeypatch.setattr("coolrl.lost_cities.deep_cfr.config.os.cpu_count", lambda: 1)
+    monkeypatch.setitem(sys.modules, "psutil", types.SimpleNamespace(cpu_count=lambda logical=False: None))
+    cfg = config_from_dict(
+        {
+            "traversal": {
+                "num_workers": "auto",
+                "traversals_per_player": 0,
+                "traversal_worker_chunk_size": 4,
+            }
+        }
+    )
+
+    resolved, is_auto, cpu_guess, num_batches = cfg.traversal.resolved_num_workers_for_traversal()
+
+    assert resolved == 1
+    assert is_auto is True
+    assert cpu_guess == 1
+    assert num_batches == 0
+
+
+def test_traversal_num_workers_auto_falls_back_without_psutil(monkeypatch) -> None:
+    monkeypatch.setattr("coolrl.lost_cities.deep_cfr.config.os.cpu_count", lambda: 12)
+    monkeypatch.delitem(sys.modules, "psutil", raising=False)
+    real_import = __import__
+
+    def _fake_import(name, *args, **kwargs):
+        if name == "psutil":
+            raise ImportError("psutil not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", _fake_import)
+    cfg = config_from_dict(
+        {
+            "traversal": {
+                "num_workers": "auto",
+                "traversals_per_player": 20,
+                "traversal_worker_chunk_size": 4,
+            }
+        }
+    )
+
+    resolved, is_auto, cpu_guess, num_batches = cfg.traversal.resolved_num_workers_for_traversal()
+
+    assert resolved == 6
+    assert is_auto is True
+    assert cpu_guess == 6
+    assert num_batches == 10
+
+
+def test_traversal_num_workers_auto_prefers_physical_core_count(monkeypatch) -> None:
+    monkeypatch.setattr("coolrl.lost_cities.deep_cfr.config.os.cpu_count", lambda: 32)
+    monkeypatch.setitem(sys.modules, "psutil", types.SimpleNamespace(cpu_count=lambda logical=False: 14))
+    cfg = config_from_dict(
+        {
+            "traversal": {
+                "num_workers": "auto",
+                "traversals_per_player": 20,
+                "traversal_worker_chunk_size": 4,
+            }
+        }
+    )
+
+    resolved, is_auto, cpu_guess, num_batches = cfg.traversal.resolved_num_workers_for_traversal()
+
+    assert resolved == 10
+    assert is_auto is True
+    assert cpu_guess == 14
+    assert num_batches == 10


### PR DESCRIPTION
## 변경 내용
- `traversal.num_workers: auto`가 논리 CPU 전체 대신 physical core 우선, 없으면 logical CPU 절반 기준으로 worker 수를 추정하도록 변경했습니다.
- auto worker 수를 `num_batches`로 상한 처리해서 과도한 multiprocessing 요청을 막았습니다.
- trainer 시작 시 auto 해석 결과를 `cpu_guess`와 `num_batches`와 함께 로그로 남기도록 했습니다.
- explicit worker 값, batch cap, 최소 1 보장, psutil 미설치 fallback, physical-core 우선 경로를 검증하는 테스트를 추가했습니다.

## 원인
기존 구현은 `os.cpu_count()`를 그대로 사용해서 Python multiprocessing traversal workload에서 SMT/Hyper-Threading 환경에 과도한 worker 수를 요청할 수 있었습니다.

## 검증
- `uv run pytest -q src/coolrl/lost_cities/tests/test_deep_cfr_config.py`
- `uv run pytest -q src/coolrl/lost_cities/tests/test_deep_cfr_smoke.py -k "traversal_benchmark_mp_mode"`

Closes #28